### PR TITLE
Database setup 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv/
 __pycache__/
+migrations/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 __pycache__/
 migrations/
+.env

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Always follow these practices whenever you are installing/uninstalling Python de
 
 Open MySQL Workbench, which was included in MySQL Server. In the top menu bar, select *Database > Connect to Database*. Enter the appropriate credentials and click OK. In the new tab, go to the Navigator pane on the left and double-click the *dry_weight_watchers* database to select it (it will turn bold). In the Query pane in the center, you can run SQL commands on the database. Try using `select * from <TableName>` to see some data. 
 
+When you first run the development server, you'll need to enter your database credentials into an `.env` file to ensure Django can access the database without exposing sensitive info to the repo. Follow the instructions in the `.env_template` file. 
+
 ### Running the application: 
 
 To run the mobile front-end, navigate to `dww_patient` and run `npx expo start`. It will start a local development server and output a QR code. Scan the code with your phone to open the app in Expo Go, or go to `http://localhost:8081` to open the app in a browser. Your phone must be connected to the same wifi network as your development machine for Expo Go to work. 

--- a/dww_backend/.env_template
+++ b/dww_backend/.env_template
@@ -1,0 +1,16 @@
+
+# INSTRUCTIONS TO SETUP DATABASE WITH DJANGO: 
+# 1) rename this file to `.env` 
+# 2) add the appropriate credentials in the fields below 
+# 3) make sure `.env` is added to .gitignore to avoid committing sensitive info to the repo 
+
+# DB name as shown in MySQL Workbench. This is separate from the AWS identifier 
+DATABASE_NAME=
+
+# username and passwd to access the database 
+DATABASE_USER=
+DATABASE_PASSWD=
+
+# web endpoint for the database. Do NOT add https:// or mysql://, etc. to the front 
+DATABASE_HOST=
+DATABASE_PORT=

--- a/dww_backend/api/admin.py
+++ b/dww_backend/api/admin.py
@@ -1,3 +1,22 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from .models import User
 
-# Register your models here.
+class CustomUserAdmin(UserAdmin):
+    model = User
+    list_display = ('email', 'first_name', 'last_name', 'is_staff')
+    fieldsets = (
+        (None, {'fields': ('email', 'password')}),
+        ('Personal info', {'fields': ('first_name', 'last_name', 'role')}), 
+        ('Permissions', {'fields': ('is_active', 'is_staff', 'is_superuser')}),
+        ('Important dates', {'fields': ('last_login', 'date_joined')}),
+    )
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('email', 'password1', 'password2', 'role'),  
+        }),
+    )
+    ordering = ('email',)
+
+admin.site.register(User, CustomUserAdmin)

--- a/dww_backend/api/forms.py
+++ b/dww_backend/api/forms.py
@@ -1,0 +1,10 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from .models import User
+
+class CustomUserCreationForm(UserCreationForm):
+    role = forms.ChoiceField(choices=User.ROLE_CHOICES, required=True)
+
+    class Meta:
+        model = User
+        fields = ['email', 'password1', 'password2', 'role']

--- a/dww_backend/api/models.py
+++ b/dww_backend/api/models.py
@@ -1,3 +1,71 @@
 from django.db import models
+from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import BaseUserManager
 
-# Create your models here.
+class UserManager(BaseUserManager):
+    def create_user(self, email, password=None, **extra_fields):
+        if not email:
+            raise ValueError("An email is required.")
+        email = self.normalize_email(email)
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, email, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError('Superuser must have is_staff=True.')
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+
+        return self.create_user(email, password, **extra_fields)
+
+# 'Custom' user model to be used with Django's built-in authentication
+
+class User(AbstractUser):
+    PATIENT = 'patient'
+    PROVIDER = 'provider'
+    ROLE_CHOICES = [
+        (PATIENT, 'Patient'),
+        (PROVIDER, 'Doctor'),
+    ]
+
+    email = models.EmailField(unique=True)
+    username = None
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = [] 
+    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
+
+    objects = UserManager()
+
+    def __str__(self):
+        return f"{self.email}, ({self.role})"
+
+# User Role profiles for user-specific fields.
+
+class Patient(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='patient_profile')
+    medications = models.TextField(blank=True)
+
+class Provider(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='provider_profile')
+    medications = models.TextField(blank=True)
+
+# Other tables/fields with many-to-one relations to a patient profile.
+
+class TreatmentRelationship(models.Model):
+    patient = models.ForeignKey(Patient, on_delete=models.CASCADE)
+    provider = models.ForeignKey(Provider, on_delete=models.CASCADE)
+
+class WeightRecord(models.Model):
+    patient = models.ForeignKey(Patient, on_delete=models.CASCADE)
+    timestamp = models.DateTimeField(auto_now_add=True)
+    weight = models.DecimalField(max_digits=5, decimal_places=2)
+
+class PatientNote(models.Model):
+    patient = models.ForeignKey(Patient, on_delete=models.CASCADE)
+    timestamp = models.DateTimeField(auto_now_add=True)
+    note = models.TextField(blank=True)

--- a/dww_backend/api/urls.py
+++ b/dww_backend/api/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('register/', views.register, name='registered user')
+]

--- a/dww_backend/api/views.py
+++ b/dww_backend/api/views.py
@@ -1,3 +1,14 @@
 from django.shortcuts import render
+from django.contrib.auth import login
+from .forms import CustomUserCreationForm
 
-# Create your views here.
+def register(request):
+    if request.method == 'POST':
+        form = CustomUserCreationForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            return # login success signal?
+    else:
+        form = CustomUserCreationForm()
+    return # login failure signal

--- a/dww_backend/core/settings.py
+++ b/dww_backend/core/settings.py
@@ -11,10 +11,14 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
 from pathlib import Path
+from dotenv import load_dotenv 
+import os 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# load environment variables from `.env` file 
+load_dotenv()
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
@@ -77,11 +81,11 @@ WSGI_APPLICATION = "core.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        #'NAME': '',          
-        #'USER': '',         
-        #'PASSWORD': '',     
-        #'HOST': '',                   
-        #'PORT': '',  
+        'NAME': os.getenv("DATABASE_NAME"), 
+        'USER': os.getenv("DATABASE_USER"),
+        'PASSWORD': os.getenv("DATABASE_PASSWD"),
+        'HOST': os.getenv("DATABASE_HOST"),
+        'PORT': os.getenv("DATABASE_PORT")
     }
 }
 

--- a/dww_backend/core/settings.py
+++ b/dww_backend/core/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "api",
 ]
 
 MIDDLEWARE = [
@@ -76,11 +77,11 @@ WSGI_APPLICATION = "core.wsgi.application"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
-        #'NAME': insert .venv environment variables eventually,          
-        #'USER': ,         
-        #'PASSWORD': ,     
-        #'HOST': ,                   
-        #'PORT': ,  
+        #'NAME': '',          
+        #'USER': '',         
+        #'PASSWORD': '',     
+        #'HOST': '',                   
+        #'PORT': '',  
     }
 }
 
@@ -102,6 +103,8 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
+
+AUTH_USER_MODEL = 'api.User'
 
 
 # Internationalization

--- a/dww_backend/core/urls.py
+++ b/dww_backend/core/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("", include('api.urls'))
 ]

--- a/dww_backend/requirements.txt
+++ b/dww_backend/requirements.txt
@@ -1,6 +1,7 @@
 asgiref==3.8.1
 Django==5.1.4
 mysqlclient==2.2.7
+python-dotenv==1.0.1
 sqlparse==0.5.3
 typing_extensions==4.12.2
 tzdata==2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-asgiref==3.8.1
-Django==5.1.4
-sqlparse==0.5.3
-tzdata==2024.2


### PR DESCRIPTION
Continuation of Duy's database setup, but added environment variables so we can use the database credentials without exposing them in the repo. Updated the README accordingly. I installed `python-dotenv` for this so remember to activate the venv and `pip install -r requirements.txt`. 

There were previously two `requirements.txt` files - one in the root directory and one in `dww_backend`. I removed the former to avoid confusion. 

The server should be able to start and connect to the database without errors now. Follow the instructions in the `.env_template` file to enter your credentials. 