### PR TITLE
provider register form submission working. Setup CORS on server.

### DIFF
--- a/dww_backend/api/forms.py
+++ b/dww_backend/api/forms.py
@@ -8,3 +8,20 @@ class CustomUserCreationForm(UserCreationForm):
     class Meta:
         model = User
         fields = ['email', 'password1', 'password2', 'role']
+
+
+class RegisterForm (forms.Form): 
+    firstname = forms.CharField(max_length=50) 
+    lastname = forms.CharField(max_length=50) 
+    email = forms.EmailField() 
+    phone = forms.IntegerField(required=False)  # TODO: better phone number validation using a library 
+    password = forms.CharField(max_length=100) 
+    confirmPassword = forms.CharField(max_length=100) 
+
+    def clean(self): 
+        cleaned_data = super().clean() 
+        password = cleaned_data.get('password') 
+        confirmPassword = cleaned_data.get('confirmPassword') 
+        if password != confirmPassword: 
+            raise forms.ValidationError('Passwords do not match!') 
+        return cleaned_data 

--- a/dww_backend/api/urls.py
+++ b/dww_backend/api/urls.py
@@ -2,5 +2,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('test/', views.test, name='test'), 
+    path('test-register', views.test_register, name='test register'), 
     path('register/', views.register, name='registered user')
 ]

--- a/dww_backend/api/views.py
+++ b/dww_backend/api/views.py
@@ -1,6 +1,14 @@
+
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.contrib.auth import login
-from .forms import CustomUserCreationForm
+from .forms import *
+import json
+
+
+def test(request: HttpRequest): 
+    return HttpResponse("hello world") 
+
 
 def register(request):
     if request.method == 'POST':
@@ -12,3 +20,18 @@ def register(request):
     else:
         form = CustomUserCreationForm()
     return # login failure signal
+
+
+def test_register(request): 
+    if request.method != 'POST': 
+        return HttpResponse("error: wrong request type") 
+    try:
+        data = json.loads(request.body)  # Parse JSON body
+    except json.JSONDecodeError:
+        return HttpResponse("error: invalid JSON")
+    
+    form = RegisterForm(data) 
+    if form.is_valid(): 
+        return HttpResponse("registered successfully!") 
+    else: 
+        return HttpResponse("registration unsuccessful :(")

--- a/dww_backend/core/settings.py
+++ b/dww_backend/core/settings.py
@@ -41,20 +41,30 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "corsheaders",
     "api",
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware", 
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "django.middleware.csrf.CsrfViewMiddleware",
+    # "django.middleware.csrf.CsrfViewMiddleware",  # will need to deal with this later 
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
 ROOT_URLCONF = "core.urls"
+
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:5173'  # Provider frontend local dev server (Vite) 
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    'http://localhost:5173' 
+]
 
 TEMPLATES = [
     {

--- a/dww_backend/requirements.txt
+++ b/dww_backend/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.8.1
 Django==5.1.4
+django-cors-headers==4.6.0
 mysqlclient==2.2.7
 python-dotenv==1.0.1
 sqlparse==0.5.3


### PR DESCRIPTION
Provider Create Account page now submits the form to the server, which responds with a simple confirmation. 

The React page sends the request to the `/test-register` endpoint (in urls.py), which is associated with the `test_register()` view (in views.py), which validates that the entered data meets the format specified in `RegisterForm` (in forms.py). 

Installed `django-cors-headers` and modified settings.py to allow CORS. Disabled CSRF middleware for now to keep things from getting too complicated but will have to re-enable and implement CSRF tokens later. 