### PR TITLE
provider Create Account now adds user to database & displays response

### DIFF
--- a/dww_backend/api/forms.py
+++ b/dww_backend/api/forms.py
@@ -10,11 +10,11 @@ class CustomUserCreationForm(UserCreationForm):
         fields = ['email', 'password1', 'password2', 'role']
 
 
-class RegisterForm (forms.Form): 
+class RegisterProviderForm (forms.Form): 
     firstname = forms.CharField(max_length=50) 
     lastname = forms.CharField(max_length=50) 
     email = forms.EmailField() 
-    phone = forms.IntegerField(required=False)  # TODO: better phone number validation using a library 
+    phone = forms.CharField(max_length=15, required=False)  # TODO: better phone number validation using a library 
     password = forms.CharField(max_length=100) 
     confirmPassword = forms.CharField(max_length=100) 
 

--- a/dww_backend/api/models.py
+++ b/dww_backend/api/models.py
@@ -30,15 +30,19 @@ class User(AbstractUser):
     PROVIDER = 'provider'
     ROLE_CHOICES = [
         (PATIENT, 'Patient'),
-        (PROVIDER, 'Doctor'),
+        (PROVIDER, 'Provider'),
     ]
 
+    first_name = models.CharField(max_length=50) 
+    last_name = models.CharField(max_length=50) 
+    phone = models.CharField(max_length=15, blank=True, null=True) 
+    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
     email = models.EmailField(unique=True)
+    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
+
     username = None
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = [] 
-    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
-
     objects = UserManager()
 
     def __str__(self):

--- a/dww_backend/api/models.py
+++ b/dww_backend/api/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import BaseUserManager
+import random 
+import string 
 
 class UserManager(BaseUserManager):
     def create_user(self, email, password=None, **extra_fields):
@@ -24,7 +26,7 @@ class UserManager(BaseUserManager):
         return self.create_user(email, password, **extra_fields)
 
 # 'Custom' user model to be used with Django's built-in authentication
-
+# no need for separate Patient and Provider tables since they are both Users 
 class User(AbstractUser):
     PATIENT = 'patient'
     PROVIDER = 'provider'
@@ -36,40 +38,70 @@ class User(AbstractUser):
     first_name = models.CharField(max_length=50) 
     last_name = models.CharField(max_length=50) 
     phone = models.CharField(max_length=15, blank=True, null=True) 
-    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
     email = models.EmailField(unique=True)
-    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
+    shareable_id = models.CharField(max_length=9, blank=True, null=True, default=None) 
+    role = models.CharField(max_length=10, choices=ROLE_CHOICES, default=PATIENT)
 
     username = None
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = [] 
     objects = UserManager()
 
+    def generate_shareable_id(self): 
+        alphabet = string.ascii_uppercase + string.digits  # A-Z, 0-9 
+        random_id = ''.join(random.choices(alphabet, k=8)) 
+        return '-'.join([random_id[:4], random_id[4:]]) 
+    
+    def save(self, *args, **kwargs): 
+        if self.role == self.PROVIDER and not self.shareable_id: 
+            self.shareable_id = self.generate_shareable_id() 
+        super().save(*args, **kwargs) 
+
     def __str__(self):
         return f"{self.email}, ({self.role})"
+    
 
-# User Role profiles for user-specific fields.
-
-class Patient(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='patient_profile')
-    medications = models.TextField(blank=True)
-
-class Provider(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='provider_profile')
-    medications = models.TextField(blank=True)
 
 # Other tables/fields with many-to-one relations to a patient profile.
 
 class TreatmentRelationship(models.Model):
-    patient = models.ForeignKey(Patient, on_delete=models.CASCADE)
-    provider = models.ForeignKey(Provider, on_delete=models.CASCADE)
+    patient = models.ForeignKey(
+        User, 
+        limit_choices_to={'role': User.PATIENT}, 
+        on_delete=models.CASCADE, 
+        related_name='treatment_patients'
+    )
+    provider = models.ForeignKey(
+        User, 
+        limit_choices_to={'role': User.PROVIDER}, 
+        on_delete=models.CASCADE, 
+        related_name='treatment_providers'
+    )
 
 class WeightRecord(models.Model):
-    patient = models.ForeignKey(Patient, on_delete=models.CASCADE)
+    patient = models.ForeignKey(
+        User, 
+        limit_choices_to={'role': User.PATIENT}, 
+        on_delete=models.CASCADE, 
+        related_name='weight_records'
+    )
     timestamp = models.DateTimeField(auto_now_add=True)
     weight = models.DecimalField(max_digits=5, decimal_places=2)
 
 class PatientNote(models.Model):
-    patient = models.ForeignKey(Patient, on_delete=models.CASCADE)
-    timestamp = models.DateTimeField(auto_now_add=True)
+    GENERIC = 'generic' 
+    MEDICATION = 'medication' 
+    TYPE_CHOICES = [
+        (GENERIC, 'Generic'),
+        (MEDICATION, 'Medication'),
+    ]
+    patient = models.ForeignKey(
+        User, 
+        limit_choices_to={'role': User.PATIENT}, 
+        on_delete=models.CASCADE, 
+        related_name='patient_notes'
+    )
+    note_type = models.CharField(choices=TYPE_CHOICES, max_length=10, 
+                                 blank=True, null=True, default=GENERIC)
+    timestamp = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     note = models.TextField(blank=True)

--- a/dww_backend/api/urls.py
+++ b/dww_backend/api/urls.py
@@ -3,6 +3,6 @@ from . import views
 
 urlpatterns = [
     path('test/', views.test, name='test'), 
-    path('test-register', views.test_register, name='test register'), 
+    path('register-provider', views.register_provider, name='register provider'), 
     path('register/', views.register, name='registered user')
 ]

--- a/dww_provider/src/pages/Register.tsx
+++ b/dww_provider/src/pages/Register.tsx
@@ -13,15 +13,39 @@ const Register: React.FC = () => {
     confirmPassword: '',
   });
 
+  const [response, setResponse] = useState<string|null>(null); 
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Replace the below console.log with actual form submission logic
     console.log('Form submitted:', formData);
+
+    try {
+      const res = await fetch('http://localhost:8000/register-provider', {
+        method: 'POST', 
+        headers: {
+          'Content-Type': 'application/json' 
+        }, 
+        body: JSON.stringify(formData)
+      }); 
+
+      if (!res.ok) { 
+        const errorData = await res.json(); // Parse JSON error response
+        throw new Error(errorData.error || `Error: ${res.statusText}`);
+      } 
+
+      const data = await res.json(); 
+      setResponse(data.message || 'Success'); 
+
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        setResponse(`Error: ${error.message}`); 
+      }
+    }
   };
 
   return (
@@ -89,6 +113,13 @@ const Register: React.FC = () => {
 
         <button type="submit">Create Account</button>
       </form>
+
+      {response && (
+        <div>
+          <p>Server Response:</p>
+          <p>{response}</p>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This PR modified the database schema, so you'll have to run `python manage.py makemigrations` and `python manage.py migrate` to apply the database migration before running the server. 

You can verify the user gets added to the database via MySQL Workbench (or I think Django has a CLI tool for db queries but I haven't used it yet). 

The page will display the server response after submitting the form, though sometimes if there's an error you still have to check the console to get the actual error message

Still todo: 
- have better error displays for mismatching passwords (the browser automatically checks email format and whether a required field is blank) 
- better validation for phone numbers (probably using a third-party library since there are all sorts of formats) 
- make sure the Provider table in the database is being used properly (right now only User table is updated) 
- redirect user to appropriate page upon success 