### PR TITLE
Logic to create provider account

### DIFF
--- a/dww_backend/api/forms.py
+++ b/dww_backend/api/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
+from phonenumber_field.formfields import PhoneNumberField
 from .models import User
 
 class CustomUserCreationForm(UserCreationForm):
@@ -14,7 +15,9 @@ class RegisterProviderForm (forms.Form):
     firstname = forms.CharField(max_length=50) 
     lastname = forms.CharField(max_length=50) 
     email = forms.EmailField() 
-    phone = forms.CharField(max_length=15, required=False)  # TODO: better phone number validation using a library 
+    # note: phone field is flexible with formatting but will reject numbers with invalid numbers 
+    # (e.g. nonexisting area code) 
+    phone = PhoneNumberField(region='US', required=False) 
     password = forms.CharField(max_length=100) 
     confirmPassword = forms.CharField(max_length=100) 
 

--- a/dww_backend/api/models.py
+++ b/dww_backend/api/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.models import BaseUserManager
+from phonenumber_field.modelfields import PhoneNumberField
 import random 
 import string 
 
@@ -34,10 +35,9 @@ class User(AbstractUser):
         (PATIENT, 'Patient'),
         (PROVIDER, 'Provider'),
     ]
-
     first_name = models.CharField(max_length=50) 
     last_name = models.CharField(max_length=50) 
-    phone = models.CharField(max_length=15, blank=True, null=True) 
+    phone = PhoneNumberField(blank=True, null=True)
     email = models.EmailField(unique=True)
     shareable_id = models.CharField(max_length=9, blank=True, null=True, default=None) 
     role = models.CharField(max_length=10, choices=ROLE_CHOICES, default=PATIENT)
@@ -60,7 +60,6 @@ class User(AbstractUser):
     def __str__(self):
         return f"{self.email}, ({self.role})"
     
-
 
 # Other tables/fields with many-to-one relations to a patient profile.
 

--- a/dww_backend/api/models.py
+++ b/dww_backend/api/models.py
@@ -37,7 +37,8 @@ class User(AbstractUser):
     ]
     first_name = models.CharField(max_length=50) 
     last_name = models.CharField(max_length=50) 
-    phone = PhoneNumberField(blank=True, null=True)
+    # phone field is flexible with formatting but rejects invalid numbers (e.g. nonexisting area code) 
+    phone = PhoneNumberField(region='US', blank=True, null=True)
     email = models.EmailField(unique=True)
     shareable_id = models.CharField(max_length=9, blank=True, null=True, default=None) 
     role = models.CharField(max_length=10, choices=ROLE_CHOICES, default=PATIENT)

--- a/dww_backend/api/views.py
+++ b/dww_backend/api/views.py
@@ -11,6 +11,13 @@ def test(request: HttpRequest):
     return HttpResponse("hello world") 
 
 
+def error_response(message, details=None, status=400):
+    response = {"error": {"message": message}}
+    if details:
+        response["error"]["details"] = details
+    return JsonResponse(response, status=status)
+
+
 def register(request):
     if request.method == 'POST':
         form = CustomUserCreationForm(request.POST)
@@ -25,26 +32,24 @@ def register(request):
 
 def register_provider(request): 
     if request.method != 'POST': 
-        return JsonResponse({"error": "invalid request"}, status=400)
+        return error_response('invalid request') 
     try:
         data = json.loads(request.body)  # Parse JSON body
     except json.JSONDecodeError:
-        return JsonResponse({"error": "invalid request"}, status=400)
+        return error_response('invalid request') 
     
+    print(f'data: {data}')
     form = RegisterProviderForm(data) 
     if form.is_valid(): 
         try: 
-            user = User.objects.create_user(
-                first_name = form.cleaned_data.get('firstname'), 
-                last_name = form.cleaned_data.get('lastname'), 
-                email = form.cleaned_data.get('email'), 
-                phone = form.cleaned_data.get('phone'), 
-                password = form.cleaned_data.get('password'), 
-                role = User.PROVIDER
-            )
+            user = form.save(commit=False) 
+            user.role = User.PROVIDER 
+            user.set_password(form.cleaned_data['password'])
             user.save()
+
         except Exception as e: 
-            return JsonResponse({'error': f'Registration failed: {str(e)}'}, status=400)
-        return JsonResponse({"message": "registered successfully!"}, status=201)
+            print(f'error: {e}')
+            return error_response('An unexpected error occurred', status=500) 
+        return JsonResponse({}, status=201)
     else: 
-        return JsonResponse({"message": "registration unsuccessful", "errors": form.errors}, status=400)
+        return error_response('Registration unsuccessful.', details=form.errors) 

--- a/dww_backend/requirements.txt
+++ b/dww_backend/requirements.txt
@@ -1,7 +1,9 @@
 asgiref==3.8.1
 Django==5.1.4
 django-cors-headers==4.6.0
+django-phonenumber-field==8.0.0
 mysqlclient==2.2.7
+phonenumberslite==8.13.53
 python-dotenv==1.0.1
 sqlparse==0.5.3
 typing_extensions==4.12.2

--- a/dww_provider/src/components/FormErrorDisplay.tsx
+++ b/dww_provider/src/components/FormErrorDisplay.tsx
@@ -1,0 +1,47 @@
+
+import React from 'react';
+import styles from '../styles/FormErrorDisplay.module.css';
+
+
+export type ErrorDetails = {
+    [field: string]: string[];
+};
+export type ErrorObject = {
+    message: string;
+    details?: ErrorDetails;
+};
+export type FormErrorDisplayProps = {
+    error: ErrorObject | null;
+};
+
+
+const FormErrorDisplay: React.FC<FormErrorDisplayProps> = ({ error }) => {
+    if (!error || !error.message) {
+        return null; // Don't render if there is no error
+    }
+    const { message, details } = error;
+
+    return (
+      <div className={styles.errorDisplay}>
+          <p className={styles.errorMessage}>{message}</p>
+          {details && (
+              <ul className={styles.errorDetails}>
+                  {Object.entries(details).map(([field, errors]) => (
+                      <li key={field}>
+                          <strong className={styles.errorField}>{field}:</strong>
+                          <ul className={styles.errorFieldList}>
+                              {errors.map((detail, index) => (
+                                  <li key={index} className={styles.errorDetail}>
+                                      {detail}
+                                  </li>
+                              ))}
+                          </ul>
+                      </li>
+                  ))}
+              </ul>
+          )}
+      </div>
+  );
+};
+
+export default FormErrorDisplay;

--- a/dww_provider/src/pages/Register.tsx
+++ b/dww_provider/src/pages/Register.tsx
@@ -1,19 +1,21 @@
 
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom'; 
+import FormErrorDisplay, { ErrorObject } from '../components/FormErrorDisplay'; 
 import styles from '../styles/auth-forms.module.css'; 
 
 const Register: React.FC = () => {
 
   const [formData, setFormData] = useState({
-    firstname: '',
-    lastname: '',
+    first_name: '',
+    last_name: '',
     email: '',
     phone: '',
     password: '',
     confirmPassword: '',
   });
-
-  const [response, setResponse] = useState<string|null>(null); 
+  const [response, setResponse] = useState<ErrorObject|null>(null); 
+  const navigate = useNavigate(); 
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -35,15 +37,15 @@ const Register: React.FC = () => {
 
       if (!res.ok) { 
         const errorData = await res.json(); // Parse JSON error response
-        throw new Error(errorData.error || `Error: ${res.statusText}`);
-      } 
-
-      const data = await res.json(); 
-      setResponse(data.message || 'Success'); 
+        setResponse(errorData.error); 
+      } else {
+        setResponse(null); 
+        navigate('/'); 
+      }
 
     } catch (error: unknown) {
       if (error instanceof Error) {
-        setResponse(`Error: ${error.message}`); 
+        setResponse({ message: error.message }); 
       }
     }
   };
@@ -52,22 +54,22 @@ const Register: React.FC = () => {
     <div className={styles.authFormContainer}>
       <h1>Create Account</h1>
       <form onSubmit={handleSubmit}>
-          <label htmlFor="firstname" className={styles.requiredInput}>First Name:</label>
+          <label htmlFor="first_name" className={styles.requiredInput}>First Name:</label>
           <input
             type="text"
-            id="firstname"
-            name="firstname"
-            value={formData.firstname}
+            id="first_name"
+            name="first_name" 
+            value={formData.first_name}
             onChange={handleChange}
             required
           />
 
-          <label htmlFor="lastname" className={styles.requiredInput}>Last Name:</label>
+          <label htmlFor="last_name" className={styles.requiredInput}>Last Name:</label>
           <input
             type="text"
-            id="lastname"
-            name="lastname"
-            value={formData.lastname}
+            id="last_name"
+            name="last_name"
+            value={formData.last_name}
             onChange={handleChange}
             required
           />
@@ -84,9 +86,10 @@ const Register: React.FC = () => {
 
           <label htmlFor="phone">Phone:</label>
           <input
-            type="phone"
+            type="tel"
             id="phone"
             name="phone"
+            placeholder="(123) 456-7890"
             value={formData.phone}
             onChange={handleChange}
           />
@@ -113,13 +116,7 @@ const Register: React.FC = () => {
 
         <button type="submit">Create Account</button>
       </form>
-
-      {response && (
-        <div>
-          <p>Server Response:</p>
-          <p>{response}</p>
-        </div>
-      )}
+      <FormErrorDisplay error={response} />
     </div>
   );
 };

--- a/dww_provider/src/styles/FormErrorDisplay.module.css
+++ b/dww_provider/src/styles/FormErrorDisplay.module.css
@@ -1,0 +1,43 @@
+
+/* Container for the error message */
+.errorDisplay {
+    margin: 1rem;
+    border: 1px solid #e74c3c;
+    background-color: #fbeaea;
+    color: #000000;
+    border-radius: 8px;
+    padding: 16px;
+    max-width: 100%;
+    word-wrap: break-word;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* General error message styling */
+.errorMessage {
+    margin: 0 0 12px 0;
+}
+
+/* Styling for the list of error details */
+.errorDetails {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}
+
+/* Field name styling */
+.errorField {
+    text-transform: capitalize;
+    font-weight: bold;
+}
+
+/* Nested list for field-specific errors */
+.errorFieldList {
+    list-style-type: none;
+    margin: 4px 0 8px 20px;
+    padding: 0;
+}
+
+/* Individual error message styling */
+.errorDetail {
+    margin: 2px 0;
+}

--- a/dww_provider/src/styles/Navbar.module.css
+++ b/dww_provider/src/styles/Navbar.module.css
@@ -1,6 +1,6 @@
 
 .navbar {
-
+    flex-shrink: 0;
     height: 60px; 
     width: 100%;
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-asgiref==3.8.1
-Django==5.1.4
-mysqlclient==2.2.7
-sqlparse==0.5.3
-typing_extensions==4.12.2
-tzdata==2024.2


### PR DESCRIPTION
Using lite version of [this](https://django-phonenumber-field.readthedocs.io/en/latest/index.html) library to validate phone number input on the server: 

Added a generic `error_response()` function to `views.py` to help standardize error outputs from forms. Errors are JSON with the following format (the `details` item is optional): 
```
{
    'error': {
        {'message': <message>}, 
        {'details': [
            'field1': <detail>, 
            'field2': <detail>, ...
        ]
    }
}
```
Register page on the provider interface now displays error messages in a reasonably pretty way if you enter form input wrong. Currently it catches mismatching passwords, invalid phone numbers, and duplicate emails. Likely will discover more edge cases with testing. 

Changed the `RegisterProviderForm` to be a `ModelForm`, which is better because it can directly inherit fields from the associated model instead of requiring you to manually redefine all the fields, which previously could lead to mismatches between what the form accepts and what the database accepts. 

Removed the `requirements.txt` in the project root. The one in `dww_backend/` is up-to-date. 

Also I think I fixed the shrinking navbar issue Lara mentioned in a different PR. 