### PR TITLE
add Expo support for environment variables

### DIFF
--- a/dww_patient/.env_template
+++ b/dww_patient/.env_template
@@ -1,0 +1,8 @@
+
+# 1) rename this file to `.env` 
+# 2) make sure it is .gitignored 
+# 3) any .env variables that will be used with Expo Go must be prefixed with "EXPO_PUBLIC_" 
+
+
+# put your local IP address where you're running the Django server here 
+EXPO_PUBLIC_DEV_SERVER_URL=

--- a/dww_patient/app/(auth)/SignupScreen.tsx
+++ b/dww_patient/app/(auth)/SignupScreen.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, TouchableOpacity, StyleSheet, SafeAreaView } fro
 import { useNavigation } from '@react-navigation/native';
 import axios from 'axios';
 
+
 const SignupScreen = () => {
   const navigation = useNavigation();
   const [firstName, setFirstName] = useState('');
@@ -27,7 +28,7 @@ const SignupScreen = () => {
     }
 
     try {
-      const response = await axios.post('http://192.168.0.9:8000/register/', data);
+      const response = await axios.post(`${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/register/`, data);
 
       console.log('Signup successful:', response.data);
       navigation.navigate('Login');

--- a/dww_patient/package-lock.json
+++ b/dww_patient/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.1.1",
         "axios": "^1.7.9",
+        "dotenv": "^16.4.7",
         "expo": "~52.0.24",
         "expo-blur": "~14.0.1",
         "expo-constants": "~17.0.3",

--- a/dww_patient/package.json
+++ b/dww_patient/package.json
@@ -21,6 +21,7 @@
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.1.1",
     "axios": "^1.7.9",
+    "dotenv": "^16.4.7",
     "expo": "~52.0.24",
     "expo-blur": "~14.0.1",
     "expo-constants": "~17.0.3",


### PR DESCRIPTION
It was easier than I thought. I had to install dotenv, so make sure to `npm install` in the `dww_patient` directory before running. Also, fill out the `.env_template` file. Now we don't have to hardcode our local IP for the dev server. 