### PR TITLE
Input weight

### DIFF
--- a/dww_backend/api/models.py
+++ b/dww_backend/api/models.py
@@ -27,7 +27,6 @@ class UserManager(BaseUserManager):
         return self.create_user(email, password, **extra_fields)
 
 # 'Custom' user model to be used with Django's built-in authentication
-# no need for separate Patient and Provider tables since they are both Users 
 class User(AbstractUser):
     PATIENT = 'patient'
     PROVIDER = 'provider'
@@ -37,7 +36,6 @@ class User(AbstractUser):
     ]
     first_name = models.CharField(max_length=50) 
     last_name = models.CharField(max_length=50) 
-    # phone field is flexible with formatting but rejects invalid numbers (e.g. nonexisting area code) 
     phone = PhoneNumberField(region='US', blank=True, null=True)
     email = models.EmailField(unique=True)
     shareable_id = models.CharField(max_length=9, blank=True, null=True, default=None) 

--- a/dww_backend/api/serializers.py
+++ b/dww_backend/api/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from .models import WeightRecord
+
+class WeightRecordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = WeightRecord
+        fields = ['weight']
+
+    def validate_weight(self, value):
+        if value <= 0:
+            raise serializers.ValidationError("Weight must be a positive number")
+        return value

--- a/dww_backend/api/urls.py
+++ b/dww_backend/api/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('register/', views.register, name='register user'),
     path('add-relationship/', views.add_relationship, name='add_relationship'),
     path('logout/', views.logout_view, name='logout'), 
-    path('profile/', views.profile_data, name='profile') 
+    path('profile/', views.profile_data, name='profile'),
+    path('record_weight/', views.record_weight, name='record weight'), 
 ]

--- a/dww_backend/api/views.py
+++ b/dww_backend/api/views.py
@@ -9,7 +9,7 @@ from .serializers import WeightRecordSerializer
 import json
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import TokenAuthentication, SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 

--- a/dww_backend/api/views.py
+++ b/dww_backend/api/views.py
@@ -5,6 +5,7 @@ from django.http import JsonResponse
 from .forms import CustomUserCreationForm
 from api.models import *
 from .forms import *
+from .serializers import WeightRecordSerializer
 import json
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
@@ -150,10 +151,15 @@ def record_weight(request):
 
         user = request.user
         weight = request.data.get('weight')
+
+        serializer = WeightRecordSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({'error': serializer.errors}, status=400)
+
         if not weight:
             return JsonResponse({'error': 'Weight field is required'}, status=400)
-        
-        WeightRecord.objects.create(patient=user, weight=weight)
+        WeightRecord.objects.create(patient=user, weight=serializer.validated_data['weight'])
+
         return JsonResponse({'message': 'Weight recorded successfully'}, status=201)
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=500)

--- a/dww_patient/app/(home)/EnterDataScreen.tsx
+++ b/dww_patient/app/(home)/EnterDataScreen.tsx
@@ -1,18 +1,36 @@
 import React, { useState } from 'react';
 import { Text, StyleSheet, View, TextInput, Keyboard, TouchableWithoutFeedback, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import axios from 'axios';
+import { useAuth } from '../(auth)/AuthContext';
 
 const EnterDataScreen = () => {
   const navigation = useNavigation();
   const [weight, setWeight] = useState('');
+  const { authToken } = useAuth();
 
-  const handleReportData = () => {
-    if (!weight || isNaN(weight)) {
+  const handleReportData = async () => {
+    if (!weight) {
       alert('Please enter a valid weight.');
       return;
     }
-    alert(`Weight reported: ${weight}kg`);
-    setWeight(''); 
+    try {
+      const response = await axios.post(`${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/enter_weight/`, 
+        { 'weight': parseFloat(weight) }, 
+        {
+          headers: {
+            'Authorization': `Token ${authToken}`,
+            'Content-Type': 'applications/json'
+          }
+        }
+      );
+      console.log('weight input successful:', response.data);
+      alert(`Weight reported: ${weight}kg`);
+      setWeight(''); 
+    } catch (error: any) {
+      console.log('weight input error:', error.response?.data || error.message)
+      alert('Failed to report weight. Please try again.')
+    }
   };
 
   return (

--- a/dww_patient/app/(home)/EnterDataScreen.tsx
+++ b/dww_patient/app/(home)/EnterDataScreen.tsx
@@ -15,12 +15,11 @@ const EnterDataScreen = () => {
       return;
     }
     try {
-      const response = await axios.post(`${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/enter_weight/`, 
+      const response = await axios.post(`${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/record_weight/`, 
         { 'weight': parseFloat(weight) }, 
         {
           headers: {
             'Authorization': `Token ${authToken}`,
-            'Content-Type': 'applications/json'
           }
         }
       );


### PR DESCRIPTION
Added new view to views.py, formulated the tokenauth based on how add_relationship was written, unsure if there are correcter ways to implement but I assume this is the token authentication we talked about last meeting.

The inputs are maxed at 999.99 due to `weight = models.DecimalField(max_digits=5, decimal_places=2)` defined in models.
The EnterDataScreen also defaults to numeric keyboard, which should prevent negative and non-numeric values. It manually checks and errors on empty values.

I added a non-negative serializer in case we ever need to input weights on the desktop ui, but that will prrooobably never happen. It shouldn't be possible to enter a negative value in the numeric keypad on the mobile ui, but yknow.