### PR TITLE
rate limit login attempts

### DIFF
--- a/dww_backend/requirements.in
+++ b/dww_backend/requirements.in
@@ -1,6 +1,7 @@
 awsebcli==3.21.0
 django-cors-headers==4.6.0
 django-phonenumber-field==8.0.0
+django-ratelimit
 djangorestframework_simplejwt==5.4.0
 mysqlclient==2.2.7
 phonenumberslite==8.13.53

--- a/dww_backend/requirements.txt
+++ b/dww_backend/requirements.txt
@@ -37,6 +37,8 @@ django-cors-headers==4.6.0
     # via -r requirements.in
 django-phonenumber-field==8.0.0
     # via -r requirements.in
+django-ratelimit==4.1.0
+    # via -r requirements.in
 djangorestframework==3.15.2
     # via djangorestframework-simplejwt
 djangorestframework-simplejwt==5.4.0

--- a/dww_provider/src/pages/Login.tsx
+++ b/dww_provider/src/pages/Login.tsx
@@ -34,16 +34,13 @@ const Login: React.FC = () => {
         navigate('/dashboard');
       } else {
         const errorData = await response.json();
+        console.log(errorData); 
         alert(errorData.message || 'Invalid credentials');
       }
     } catch (error) {
       console.error('Login error:', error);
     }
   };
-
-
-
-
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
Login attempts limited to 5 per minute on both patient and provider interfaces. 

Installed a dependency; rerun `pip install -r requirements.txt` 

To test, you may need to temporarily modify the `@ratelimit` decorator on the `login` view to a longer time period like "1/m" or "1/2m" instead of "1/5m". 