### PR TITLE
Patient dashboard

### DIFF
--- a/dww_backend/api/urls.py
+++ b/dww_backend/api/urls.py
@@ -22,4 +22,6 @@ urlpatterns = [
     path('user/providers/delete/', views.delete_relationship, name='delete-provider'),
     path('get-csrf-token/', views.get_csrf_token, name='get_csrf_token'),
     path('get-patient-data/', views.get_patient_data, name='get_patient_data'),
+    path('get-weight-record/', views.get_weight_record, name='get weight record'),
+    path('get-patient-notes/', views.get_patient_notes, name='get patient notes'),
 ]

--- a/dww_backend/api/views.py
+++ b/dww_backend/api/views.py
@@ -414,4 +414,39 @@ def get_providers(request):
         return Response(serializer.data, status=200)
     except Exception as e:
         return Response({'error': str(e)}, status=500)
+
+@csrf_exempt
+@api_view(['GET'])   
+def get_weight_record(request):
+    try:
+        user = request.user
+
+        try:
+            weight_history = list(WeightRecord.objects.filter(
+                patient=user
+                ).order_by('timestamp').values('weight', 'timestamp'))
+        except WeightRecord.DoesNotExist:
+            return JsonResponse({'error': 'Record not found'}, status=404)
+        
+        return JsonResponse(weight_history, safe=False, status=201)
     
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=500)
+    
+@csrf_exempt
+@api_view(['GET'])   
+def get_patient_notes(request):
+    try:
+        user = request.user
+
+        try:
+            patient_notes = list(PatientNote.objects.filter(
+                patient=user
+                ).order_by('timestamp').values('note', 'timestamp'))
+        except PatientNote.DoesNotExist:
+            return JsonResponse({'error': 'Notes not found'}, status=404)
+        
+        return JsonResponse(patient_notes, safe=False, status=201)
+    
+    except Exception as e:
+        return JsonResponse({'error': str(e)}, status=500)

--- a/dww_patient/app/home/DashboardScreen.tsx
+++ b/dww_patient/app/home/DashboardScreen.tsx
@@ -1,16 +1,90 @@
 import React, { useEffect, useState } from 'react';
-import { Text } from 'react-native';
+import { Text, StyleSheet, View, TouchableOpacity, ScrollView, } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import type { HomeTabScreenProps } from '../types/navigation';
+import Chart from '../../assets/components/Chart';
+import Calendar from '../../assets/components/Calendar';
 
 const DashboardScreen = () => {
-  const navigation = useNavigation();
-  const [message, setMessage] = useState('');
+  const navigation = useNavigation<HomeTabScreenProps<'Dashboard'>['navigation']>();
+  const [chart, setChart] = useState('chart');
 
   return (
-    <Text>
-      {message}
-    </Text>
+    <View style={styles.mainContainer}>
+      <View style={styles.chartSliderContainer}>
+        <TouchableOpacity style={[styles.leftSlider, {backgroundColor: chart === 'chart' ? '#7B5CB8' : 'white'}]} onPress={() => setChart('chart')}>
+          <Text style={{color: chart === 'chart' ? 'white': 'gray'}}>
+            Chart
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={[styles.rightSlider, {backgroundColor: chart === 'calendar' ? '#7B5CB8' : 'white'}]} onPress={() => setChart('calendar')}>
+          <Text style={{color: chart === 'calendar' ? 'white': 'gray'}}>
+            Calendar
+          </Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.chartContainer}>
+        {chart === 'chart' ? <Chart/> : <Calendar/>}
+      </View>
+      <ScrollView style={styles.noteContainer}>
+
+      </ScrollView>
+    </View>
   );
 };
+
+const styles = StyleSheet.create({
+  mainContainer: {
+    flex: 1,
+    backgroundColor: 'black',
+  },
+  chartSliderContainer: {
+    padding: 10,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    backgroundColor: '#F0F0F0',
+  },
+  leftSlider: {
+    padding: 12,
+    borderTopLeftRadius: 20,
+    borderBottomLeftRadius: 20,
+    maxWidth: 120,
+    minWidth: 100,
+    alignItems: 'center',
+    borderColor: '#7B5CB8',
+    borderWidth: 1,
+    borderRightWidth: 0,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  /*middleSlider: {
+    in case I decide I want more chart types later.
+  },*/
+  rightSlider: {
+    padding: 12,
+    borderTopRightRadius: 20,
+    borderBottomRightRadius: 20,
+    maxWidth: 120,
+    minWidth: 100,
+    alignItems: 'center',
+    borderColor: '#7B5CB8',
+    borderWidth: 1,
+    borderLeftWidth: 0,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  chartContainer: {
+    flex: 2,
+    //padding: 12,
+    backgroundColor: 'white',
+    justifyContent: 'center',
+  },
+  noteContainer: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+});
 
 export default DashboardScreen;

--- a/dww_patient/app/home/DashboardScreen.tsx
+++ b/dww_patient/app/home/DashboardScreen.tsx
@@ -8,6 +8,11 @@ import Calendar from '../../assets/components/Calendar';
 const DashboardScreen = () => {
   const navigation = useNavigation<HomeTabScreenProps<'Dashboard'>['navigation']>();
   const [chart, setChart] = useState('chart');
+  const [selectedDay, setSelectedDay] = useState<{
+    day: Date;
+    weight?: number;
+    notes?: string;
+  } | null>(null);
 
   return (
     <View style={styles.mainContainer}>
@@ -24,7 +29,7 @@ const DashboardScreen = () => {
         </TouchableOpacity>
       </View>
       <View style={styles.chartContainer}>
-        {chart === 'chart' ? <Chart date={new Date()}/> : <Calendar/>}
+        {chart === 'chart' ? <Chart date={new Date()} data={null}/> : <Calendar/>}
       </View>
       <ScrollView style={styles.noteContainer}>
 

--- a/dww_patient/app/home/DashboardScreen.tsx
+++ b/dww_patient/app/home/DashboardScreen.tsx
@@ -24,7 +24,7 @@ const DashboardScreen = () => {
         </TouchableOpacity>
       </View>
       <View style={styles.chartContainer}>
-        {chart === 'chart' ? <Chart/> : <Calendar/>}
+        {chart === 'chart' ? <Chart date={new Date()}/> : <Calendar/>}
       </View>
       <ScrollView style={styles.noteContainer}>
 
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
   },
   chartContainer: {
     flex: 2,
-    //padding: 12,
+    padding: 12,
     backgroundColor: 'white',
     justifyContent: 'center',
   },

--- a/dww_patient/assets/components/Calendar.tsx
+++ b/dww_patient/assets/components/Calendar.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import { View, Dimensions } from 'react-native';
+import React, { useState } from 'react';
+import { View, LayoutChangeEvent } from 'react-native';
 import Svg, { Rect, Text, G } from 'react-native-svg';
 
 const Calendar = () => {
-  const { width } = Dimensions.get('window');
-  const CELL_SIZE = width / 7;
-  const PADDING = 12;
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const CELL_SIZE = dimensions.width / 7;
   const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   
   const today = new Date();
@@ -13,6 +12,11 @@ const Calendar = () => {
   const month = today.getMonth();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
   const firstDayOfMonth = new Date(year, month, 1).getDay();
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setDimensions({ width, height });
+  };
 
   const grid = [];
   let dayCounter = 1;
@@ -34,8 +38,8 @@ const Calendar = () => {
   }
 
   return (
-    <View style={{ flex: 1, padding: PADDING }}>
-      <Svg width={width - 2 * PADDING} height={CELL_SIZE * 7} viewBox={`0 0 ${width} ${CELL_SIZE * 7}`} preserveAspectRatio="xMinYMin meet">
+    <View style={{ flex: 1 }} onLayout={onLayout}>
+      <Svg width={dimensions.width} height={dimensions.height} viewBox={`0 0 ${dimensions.width} ${dimensions.height}`} preserveAspectRatio="xMinYMin meet">
         <G>
           {DAYS.map((day, index) => (
             <Text

--- a/dww_patient/assets/components/Calendar.tsx
+++ b/dww_patient/assets/components/Calendar.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, Dimensions } from 'react-native';
+import Svg, { Rect, Text, G } from 'react-native-svg';
+
+const Calendar = () => {
+  const { width } = Dimensions.get('window');
+  const CELL_SIZE = width / 7;
+  const PADDING = 12;
+  const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstDayOfMonth = new Date(year, month, 1).getDay();
+
+  const grid = [];
+  let dayCounter = 1;
+
+  for (let row = 0; row < 6; row++) {
+    for (let col = 0; col < 7; col++) {
+      const isFirstRow = row === 0;
+      const isEmpty = (row === 0 && col < firstDayOfMonth) || dayCounter > daysInMonth;
+      const date = isEmpty ? '' : dayCounter;
+
+      grid.push({
+        x: col * CELL_SIZE,
+        y: row * CELL_SIZE + (isFirstRow ? CELL_SIZE : 0), 
+        date,
+      });
+
+      if (!isEmpty) dayCounter++;
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, padding: PADDING }}>
+      <Svg width={width - 2 * PADDING} height={CELL_SIZE * 7} viewBox={`0 0 ${width} ${CELL_SIZE * 7}`} preserveAspectRatio="xMinYMin meet">
+        <G>
+          {DAYS.map((day, index) => (
+            <Text
+              key={day}
+              x={index * CELL_SIZE + CELL_SIZE / 2}
+              y={CELL_SIZE / 2}
+              textAnchor="middle"
+              alignmentBaseline="central"
+              fill="#7B5CB8"
+              fontSize={14}
+            >
+              {day}
+            </Text>
+          ))}
+        </G>
+
+        {grid.map((cell, index) => (
+          <G key={index}>
+            <Rect
+              x={cell.x}
+              y={cell.y}
+              width={CELL_SIZE}
+              height={CELL_SIZE}
+              fill="white"
+              stroke="#F0F0F0"
+              strokeWidth={1}
+            />
+            <Text
+              x={cell.x + CELL_SIZE / 2}
+              y={cell.y + CELL_SIZE / 2}
+              textAnchor="middle"
+              alignmentBaseline="central"
+              fill={cell.date === today.getDate() ? '#7B5CB8' : '#333'}
+              fontWeight={cell.date === today.getDate() ? 'bold' : 'normal'}
+            >
+              {cell.date}
+            </Text>
+          </G>
+        ))}
+      </Svg>
+    </View>
+  );
+};
+
+export default Calendar;

--- a/dww_patient/assets/components/Chart.tsx
+++ b/dww_patient/assets/components/Chart.tsx
@@ -4,7 +4,14 @@ import Svg, { Text, Line, Path, Circle, G } from 'react-native-svg';
 
 type CalendarProps = {
   date: Date
-  //data: any
+  data: Array<{
+    day: Date;
+    weight: number;
+  }>;
+  onDataPointSelect: (selectedData: {
+    day: Date;
+    weight: number;
+  }) => void;
 };
 
 const Chart = ({ date }: CalendarProps) => { //add data as param later

--- a/dww_patient/assets/components/Chart.tsx
+++ b/dww_patient/assets/components/Chart.tsx
@@ -1,0 +1,19 @@
+import { Svg, Line, Path, Circle, G } from 'react-native-svg';
+
+const Chart = () => (
+  <Svg width="100%" height="100%">
+    <Line x1="10%" y1="90%" x2="90%" y2="90%" stroke="gray" />
+    <Line x1="10%" y1="90%" x2="10%" y2="10%" stroke="gray" />
+    
+    <Path
+      d="M10% 90% L30% 70% L50% 50% ..."
+      stroke="#7B5CB8"
+      strokeWidth={2}
+      fill="none"
+    />
+    
+    <Circle cx="30%" cy="70%" r="4" fill="#7B5CB8" />
+  </Svg>
+);
+
+export default Chart;

--- a/dww_patient/assets/components/Chart.tsx
+++ b/dww_patient/assets/components/Chart.tsx
@@ -10,7 +10,6 @@ type ChartProps = {
   }>;
   onDataPointSelect: (selectedData: { //function to interact with selected days in screen
     day: Date;
-    weight: number;
   }) => void;
 };
 
@@ -22,8 +21,9 @@ type WeightRecord = {
 const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => { 
   const [selectedMonth, setSelectedMonth] = useState(new Date());
   const [selectedMonthRecord, setSelectedMonthRecord] = useState<WeightRecord[]>([]);
+  const [selectedDay, setSelectedDay] = useState(new Date());
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-  const MARGIN = 60;
+  const MARGIN = 48;
 
   const onLayout = (event: LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
@@ -95,7 +95,7 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
 
   // draw axes (line x2), gridlines, line (path), then interactable points (circles)
   return (
-    <View style={{ flex: 1 }} onLayout={onLayout}>
+    <View style={{ flex: 1 }}>
 
       <View style={styles.monthHeader}>
         <TouchableOpacity onPress={handlePrevMonth}>
@@ -111,105 +111,109 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
         </TouchableOpacity>
       </View>
 
-      <View style={styles.chartContainer}>
-      <Svg width={dimensions.width} height={dimensions.height} viewBox={`0 0 ${dimensions.width} ${dimensions.height}`} preserveAspectRatio="xMinYMin meet">
+      <View style={styles.chartContainer} onLayout={onLayout}>
+        <Svg width={dimensions.width} height={dimensions.height}>
 
-        <Line
-          x1={MARGIN}
-          y1={dimensions.height - MARGIN}
-          x2={dimensions.width - MARGIN}
-          y2={dimensions.height - MARGIN}
-          stroke="black"
-          strokeWidth="1"
-        />
-        <Line
-          x1={MARGIN}
-          y1={MARGIN}
-          x2={MARGIN}
-          y2={dimensions.height - MARGIN}
-          stroke="black"
-          strokeWidth="1"
-        />
+          <Line
+            x1={MARGIN}
+            y1={dimensions.height - MARGIN}
+            x2={dimensions.width - MARGIN}
+            y2={dimensions.height - MARGIN}
+            stroke="black"
+            strokeWidth="1"
+          />
+          <Line
+            x1={MARGIN}
+            y1={MARGIN}
+            x2={MARGIN}
+            y2={dimensions.height - MARGIN}
+            stroke="black"
+            strokeWidth="1"
+          />
 
-        {generateYAxisGrid().map((gridValue) => {
-          const y = yScale(gridValue);
-          if (isNaN(gridValue)) return null;
-          return (
-            <G key={`y-${gridValue}`}>
-              <Line
-                x1={MARGIN}
-                y1={y}
-                x2={dimensions.width - MARGIN}
-                y2={y}
-                stroke="#E0E0E0"
-                strokeWidth="0.5"
-                opacity={0.5}
-              />
-              <SvgText
-                x={MARGIN - 10}
-                y={y + 4}
-                textAnchor="end"
-                fill="#666"
-                fontSize="10"
-              >
-                {Math.round(gridValue)}
-              </SvgText>
-            </G>
-          );
-        })}
-
-        {generateXAxisGrid(selectedMonth).map((day) => {
-          const tempDate = new Date(selectedMonth);
-          tempDate.setDate(day);
-          const x = xScale(tempDate);
-          return (
-            <G key={`x-${day}`}>
-              <Line
-                x1={x}
-                y1={MARGIN}
-                x2={x}
-                y2={dimensions.height - MARGIN}
-                stroke="#E0E0E0"
-                strokeWidth="0.5"
-                opacity={0.5}
-              />
-              {day % 5 === 0 && (
+          {generateYAxisGrid().map((gridValue) => {
+            const y = yScale(gridValue);
+            if (isNaN(gridValue)) return null;
+            return (
+              <G key={`y-${gridValue}`}>
+                <Line
+                  x1={MARGIN}
+                  y1={y}
+                  x2={dimensions.width - MARGIN}
+                  y2={y}
+                  stroke="#E0E0E0"
+                  strokeWidth="0.5"
+                  opacity={0.5}
+                />
                 <SvgText
-                  x={x}
-                  y={dimensions.height - MARGIN + 15}
-                  textAnchor="middle"
+                  x={MARGIN - 10}
+                  y={y + 4}
+                  textAnchor="end"
                   fill="#666"
                   fontSize="10"
                 >
-                  {`${selectedMonth.getMonth() + 1}/${day}`}
+                  {Math.round(gridValue)}
                 </SvgText>
-              )}
-            </G>
-          );
-        })}
+              </G>
+            );
+          })}
 
-        <Path
-          d={path}
-          stroke="#7B5CB8"
-          strokeWidth="2"
-          fill="none"
-        />
+          {generateXAxisGrid(selectedMonth).map((day) => {
+            if (day % 5 === 0) {
+              const tempDate = new Date(selectedMonth);
+              tempDate.setDate(day);
+              const x = xScale(tempDate);
+              return (
+                <G key={`x-${day}`}>
+                  <Line
+                    x1={x}
+                    y1={MARGIN}
+                    x2={x}
+                    y2={dimensions.height - MARGIN}
+                    stroke="#E0E0E0"
+                    strokeWidth="0.5"
+                    opacity={0.5}
+                  />
+                  <SvgText
+                    x={x}
+                    y={dimensions.height - MARGIN + 15}
+                    textAnchor="middle"
+                    fill="#666"
+                    fontSize="10"
+                  >
+                    {`${selectedMonth.getMonth() + 1}/${day}`}
+                  </SvgText>
+                </G>
+              );
+            }
+            return null; 
+          })}
 
-        {selectedMonthRecord.map((point, index) => {
-          const x = xScale(point.timestamp);
-          const y = yScale(point.weight);
-          return (
-            <G key={index}>
-              <Circle
-                cx={x}
-                cy={y}
-                r="6"
-                fill="#7B5CB8"
-                onPress={() => onDataPointSelect} 
-              />
-            </G>
-          );
-        })}
+
+          <Path
+            d={path}
+            stroke="#7B5CB8"
+            strokeWidth="2"
+            fill="none"
+          />
+
+          {selectedMonthRecord.map((point, index) => {
+            const x = xScale(point.timestamp);
+            const y = yScale(point.weight);
+            const isSelected = selectedDay && selectedDay.getTime() === point.timestamp.getTime();
+            return (
+              <G key={index}>
+                <Circle
+                  cx={x}
+                  cy={y}
+                  r={isSelected ? "8" : "6"}
+                  fill={isSelected ? "#4f3582" : "#7B5CB8"}
+                  onPress={() => { setSelectedDay(point.timestamp); onDataPointSelect({ day: point.timestamp }); }}
+                />
+              </G>
+            );
+          })}
+
 
         </Svg>
       </View>
@@ -237,6 +241,7 @@ const styles = StyleSheet.create({
   chartContainer: {
     borderColor: '#7B5CB8',
     borderWidth: 1,
+    flex: 1,
   },
 });
 

--- a/dww_patient/assets/components/Chart.tsx
+++ b/dww_patient/assets/components/Chart.tsx
@@ -1,19 +1,109 @@
-import { Svg, Line, Path, Circle, G } from 'react-native-svg';
+import React, { useState } from 'react';
+import { View, LayoutChangeEvent } from 'react-native';
+import Svg, { Text, Line, Path, Circle, G } from 'react-native-svg';
 
-const Chart = () => (
-  <Svg width="100%" height="100%">
-    <Line x1="10%" y1="90%" x2="90%" y2="90%" stroke="gray" />
-    <Line x1="10%" y1="90%" x2="10%" y2="10%" stroke="gray" />
-    
-    <Path
-      d="M10% 90% L30% 70% L50% 50% ..."
-      stroke="#7B5CB8"
-      strokeWidth={2}
-      fill="none"
-    />
-    
-    <Circle cx="30%" cy="70%" r="4" fill="#7B5CB8" />
-  </Svg>
-);
+type CalendarProps = {
+  date: Date
+  //data: any
+};
+
+const Chart = ({ date }: CalendarProps) => { //add data as param later
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const MARGIN = 24;
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setDimensions({ width, height });
+  };
+
+  const data = [
+    { day: new Date(2024, 2, 1), weight: 68 },
+    { day: new Date(2024, 2, 5), weight: 67 },
+    { day: new Date(2024, 2, 10), weight: 66 },
+    { day: new Date(2024, 2, 15), weight: 65 },
+    { day: new Date(2024, 2, 20), weight: 64 },
+    { day: new Date(2024, 2, 28), weight: 63 },
+  ];
+
+  //calc x coord for where a day should be.
+  // `day / days in month` for an 'index scale', like 1/31. Then multiply by chart width - 2margin to get where it should be in the graph. Margins included to give space for axis label
+  const xScale = (day: Date) => {
+    return ((day.getDate()) / (new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate())) * (dimensions.width - MARGIN * 2) + MARGIN;
+  };
+
+  //calc y coord for where height shoud be scaled to. Similar theory to xScale. +-20 height margin is arbitrary.
+  const yScale = (weight: number) => {
+    const minWeight = Math.min(...data.map(d => d.weight)) - 20;
+    const maxWeight = Math.max(...data.map(d => d.weight)) + 20;
+    return dimensions.height - MARGIN - ((weight - minWeight) / (maxWeight - minWeight)) * (dimensions.height - MARGIN * 2);
+  };
+
+  let path = '';
+  data.forEach((point, index) => {
+    if (index === 0) {
+      path += `M ${xScale(point.day)} ${yScale(point.weight)} `;
+    } else {
+      path += `L ${xScale(point.day)} ${yScale(point.weight)} `;
+    }
+  });
+
+  // draw axes, line (path), then interactable points (circles)
+  return (
+    <View style={{ flex: 1 }} onLayout={onLayout}>
+      <Svg width={dimensions.width} height={dimensions.height} viewBox={`0 0 ${dimensions.width} ${dimensions.height}`} preserveAspectRatio="xMinYMin meet">
+
+        <Line
+          x1={MARGIN}
+          y1={dimensions.height - MARGIN}
+          x2={dimensions.width - MARGIN}
+          y2={dimensions.height - MARGIN}
+          stroke="black"
+          strokeWidth="1"
+        />
+        <Line
+          x1={MARGIN}
+          y1={MARGIN}
+          x2={MARGIN}
+          y2={dimensions.height - MARGIN}
+          stroke="black"
+          strokeWidth="1"
+        />
+
+        <Path
+          d={path}
+          stroke="#7B5CB8"
+          strokeWidth="2"
+          fill="none"
+        />
+
+        {data.map((point, index) => {
+          const x = xScale(point.day);
+          const y = yScale(point.weight);
+          return (
+            <G key={index}>
+              <Circle
+                cx={x}
+                cy={y}
+                r="6"
+                fill="#7B5CB8"
+                onPress={() => console.log('Selected:', point)} 
+              />
+              <Text
+                x={x}
+                y={y - 15}
+                textAnchor="middle"
+                fill="#7B5CB8"
+                fontSize="12"
+              >
+                {point.weight}lbs
+              </Text>
+            </G>
+          );
+        })}
+
+      </Svg>
+    </View>
+  )
+};
 
 export default Chart;

--- a/dww_patient/assets/components/Chart.tsx
+++ b/dww_patient/assets/components/Chart.tsx
@@ -1,62 +1,117 @@
-import React, { useState } from 'react';
-import { View, LayoutChangeEvent } from 'react-native';
-import Svg, { Text, Line, Path, Circle, G } from 'react-native-svg';
+import React, { useState, useEffect } from 'react';
+import { View, LayoutChangeEvent, TouchableOpacity, StyleSheet, Text } from 'react-native';
+import Svg, { Text as SvgText, Line, Path, Circle, G } from 'react-native-svg';
+import Ionicons from '@expo/vector-icons/Ionicons'; 
 
-type CalendarProps = {
-  date: Date
-  data: Array<{
-    day: Date;
+type ChartProps = {
+  weightRecord: Array<{ //weight data to draw chart
+    timestamp: Date;
     weight: number;
   }>;
-  onDataPointSelect: (selectedData: {
+  onDataPointSelect: (selectedData: { //function to interact with selected days in screen
     day: Date;
     weight: number;
   }) => void;
 };
 
-const Chart = ({ date }: CalendarProps) => { //add data as param later
+type WeightRecord = {
+  timestamp: Date,
+  weight: number,
+}
+
+const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => { 
+  const [selectedMonth, setSelectedMonth] = useState(new Date());
+  const [selectedMonthRecord, setSelectedMonthRecord] = useState<WeightRecord[]>([]);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-  const MARGIN = 24;
+  const MARGIN = 60;
 
   const onLayout = (event: LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
     setDimensions({ width, height });
   };
 
-  const data = [
-    { day: new Date(2024, 2, 1), weight: 68 },
-    { day: new Date(2024, 2, 5), weight: 67 },
-    { day: new Date(2024, 2, 10), weight: 66 },
-    { day: new Date(2024, 2, 15), weight: 65 },
-    { day: new Date(2024, 2, 20), weight: 64 },
-    { day: new Date(2024, 2, 28), weight: 63 },
-  ];
+  const handleNextMonth = () => {
+    let nextMonth = new Date(selectedMonth);
+    nextMonth.setMonth(nextMonth.getMonth() + 1); // cant do this in one-liner because .setMonth returns milliseconds and not a Date object (WHYYY)
+    setSelectedMonth(nextMonth); //we need to do setSelectedMonth to change state and re-render component, but we cant do one-liner because of the above.
+  }
+
+  const handlePrevMonth = () => {
+    let nextMonth = new Date(selectedMonth);
+    nextMonth.setMonth(nextMonth.getMonth() - 1); // x2
+    setSelectedMonth(nextMonth); //cant do setState( new Date(date.setMonth + 1) ) because it recalculates it a second time in UTC and add/removes excess hours. This would cause issues if the timestamp is near midnight.
+  }
 
   //calc x coord for where a day should be.
   // `day / days in month` for an 'index scale', like 1/31. Then multiply by chart width - 2margin to get where it should be in the graph. Margins included to give space for axis label
   const xScale = (day: Date) => {
-    return ((day.getDate()) / (new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate())) * (dimensions.width - MARGIN * 2) + MARGIN;
+    return ((day.getDate()) / (new Date(selectedMonth.getFullYear(), selectedMonth.getMonth() + 1, 0).getDate())) * (dimensions.width - MARGIN * 2) + MARGIN;
   };
 
-  //calc y coord for where height shoud be scaled to. Similar theory to xScale. +-20 height margin is arbitrary.
+  //calc y coord for where height shoud be scaled to. Similar theory to xScale.
   const yScale = (weight: number) => {
-    const minWeight = Math.min(...data.map(d => d.weight)) - 20;
-    const maxWeight = Math.max(...data.map(d => d.weight)) + 20;
     return dimensions.height - MARGIN - ((weight - minWeight) / (maxWeight - minWeight)) * (dimensions.height - MARGIN * 2);
   };
 
+  //generate 7 grid lines, range / 6 represents the spaces inbetween (grid lines - 1)
+  const generateYAxisGrid = () => {
+    const range = maxWeight - minWeight;
+    return Array.from({ length: 7 }, (_, i) => minWeight + i * (range / 6));
+  };
+  
+  const generateXAxisGrid = (month: Date) => {
+    return Array.from({ length: new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate() }, (_, i) => i + 1);
+  };
+
+  //selectedMonthRecord = filtered weight record for selectedMonth.
+  useEffect(() => {
+    const filteredData = weightRecord.filter((point) => {
+      return (
+        point.timestamp.getFullYear() === selectedMonth.getFullYear() &&
+        point.timestamp.getMonth() === selectedMonth.getMonth()
+      );
+    });
+    setSelectedMonthRecord(filteredData);
+  }, [selectedMonth, weightRecord]);
+
+  //some calculations used for yScale and yGrid
+  //basically it pads the y-dimension by a constant value of +-5lbs alongside the range of the patient's weight record, scaling the y-axis in case the patient sees a dramatic weight change
+  //theoretically this makes it so the graph doesn't look exceedingly goofy if the range of the patient's weight change is like >=10 lbs in one month. the line always takes the inner 1/3 of graph space
+  const range = Math.max(...selectedMonthRecord.map(d => d.weight)) - Math.min(...selectedMonthRecord.map(d => d.weight));
+  const padding = range + 5;
+  const minWeight = Math.min(...selectedMonthRecord.map(d => d.weight)) - padding;
+  const maxWeight = Math.max(...selectedMonthRecord.map(d => d.weight)) + padding;
+
+  //draw path, 'M' to move to first point location, then 'L' to move while drawing the line onwards.
+  //TODO: special behavior for missing days while drawing?
   let path = '';
-  data.forEach((point, index) => {
+  selectedMonthRecord.forEach((point, index) => {
     if (index === 0) {
-      path += `M ${xScale(point.day)} ${yScale(point.weight)} `;
+      path += `M ${xScale(point.timestamp)} ${yScale(point.weight)} `;
     } else {
-      path += `L ${xScale(point.day)} ${yScale(point.weight)} `;
+      path += `L ${xScale(point.timestamp)} ${yScale(point.weight)} `;
     }
   });
 
-  // draw axes, line (path), then interactable points (circles)
+  // draw axes (line x2), gridlines, line (path), then interactable points (circles)
   return (
     <View style={{ flex: 1 }} onLayout={onLayout}>
+
+      <View style={styles.monthHeader}>
+        <TouchableOpacity onPress={handlePrevMonth}>
+          <Ionicons name="chevron-back" size={24} color="#7B5CB8" />
+        </TouchableOpacity>
+        
+        <Text style={styles.monthText}>
+          {selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+        </Text>
+        
+        <TouchableOpacity onPress={handleNextMonth}>
+          <Ionicons name="chevron-forward" size={24} color="#7B5CB8" />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.chartContainer}>
       <Svg width={dimensions.width} height={dimensions.height} viewBox={`0 0 ${dimensions.width} ${dimensions.height}`} preserveAspectRatio="xMinYMin meet">
 
         <Line
@@ -76,6 +131,63 @@ const Chart = ({ date }: CalendarProps) => { //add data as param later
           strokeWidth="1"
         />
 
+        {generateYAxisGrid().map((gridValue) => {
+          const y = yScale(gridValue);
+          if (isNaN(gridValue)) return null;
+          return (
+            <G key={`y-${gridValue}`}>
+              <Line
+                x1={MARGIN}
+                y1={y}
+                x2={dimensions.width - MARGIN}
+                y2={y}
+                stroke="#E0E0E0"
+                strokeWidth="0.5"
+                opacity={0.5}
+              />
+              <SvgText
+                x={MARGIN - 10}
+                y={y + 4}
+                textAnchor="end"
+                fill="#666"
+                fontSize="10"
+              >
+                {Math.round(gridValue)}
+              </SvgText>
+            </G>
+          );
+        })}
+
+        {generateXAxisGrid(selectedMonth).map((day) => {
+          const tempDate = new Date(selectedMonth);
+          tempDate.setDate(day);
+          const x = xScale(tempDate);
+          return (
+            <G key={`x-${day}`}>
+              <Line
+                x1={x}
+                y1={MARGIN}
+                x2={x}
+                y2={dimensions.height - MARGIN}
+                stroke="#E0E0E0"
+                strokeWidth="0.5"
+                opacity={0.5}
+              />
+              {day % 5 === 0 && (
+                <SvgText
+                  x={x}
+                  y={dimensions.height - MARGIN + 15}
+                  textAnchor="middle"
+                  fill="#666"
+                  fontSize="10"
+                >
+                  {`${selectedMonth.getMonth() + 1}/${day}`}
+                </SvgText>
+              )}
+            </G>
+          );
+        })}
+
         <Path
           d={path}
           stroke="#7B5CB8"
@@ -83,8 +195,8 @@ const Chart = ({ date }: CalendarProps) => { //add data as param later
           fill="none"
         />
 
-        {data.map((point, index) => {
-          const x = xScale(point.day);
+        {selectedMonthRecord.map((point, index) => {
+          const x = xScale(point.timestamp);
           const y = yScale(point.weight);
           return (
             <G key={index}>
@@ -93,24 +205,39 @@ const Chart = ({ date }: CalendarProps) => { //add data as param later
                 cy={y}
                 r="6"
                 fill="#7B5CB8"
-                onPress={() => console.log('Selected:', point)} 
+                onPress={() => onDataPointSelect} 
               />
-              <Text
-                x={x}
-                y={y - 15}
-                textAnchor="middle"
-                fill="#7B5CB8"
-                fontSize="12"
-              >
-                {point.weight}lbs
-              </Text>
             </G>
           );
         })}
 
-      </Svg>
+        </Svg>
+      </View>
     </View>
   )
 };
+
+const styles = StyleSheet.create({
+  monthHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 5,
+    borderColor: '#7B5CB8',
+    borderWidth: 1,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+  },
+  monthText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#4f3582',
+  },
+  chartContainer: {
+    borderColor: '#7B5CB8',
+    borderWidth: 1,
+  },
+});
 
 export default Chart;

--- a/dww_patient/package-lock.json
+++ b/dww_patient/package-lock.json
@@ -36,6 +36,7 @@
         "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0",
+        "react-native-svg": "^15.11.1",
         "react-native-web": "~0.19.13",
         "react-native-webview": "13.12.5"
       },
@@ -5329,6 +5330,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bplist-creator": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
@@ -6185,6 +6192,56 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -6477,6 +6534,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -6489,6 +6572,35 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -6606,7 +6718,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -10426,6 +10537,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -11284,6 +11401,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -12428,6 +12557,21 @@
       "dependencies": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.11.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.11.1.tgz",
+      "integrity": "sha512-Qmwx/yJKt+AHUr4zjxx/Q69qwKtRfr1+uIfFMQoq3WFRhqU76aL9db1DyvPiY632DAsVGba1pHf92OZPkpjrdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/dww_patient/package.json
+++ b/dww_patient/package.json
@@ -28,7 +28,9 @@
     "expo-font": "~13.0.2",
     "expo-haptics": "~14.0.0",
     "expo-linking": "~7.0.3",
+    "expo-notifications": "~0.29.13",
     "expo-router": "~4.0.17",
+    "expo-secure-store": "~14.0.1",
     "expo-splash-screen": "^0.29.21",
     "expo-status-bar": "~2.0.0",
     "expo-symbols": "~0.2.0",
@@ -41,10 +43,9 @@
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
+    "react-native-svg": "^15.11.1",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5",
-    "expo-secure-store": "~14.0.1",
-    "expo-notifications": "~0.29.13"
+    "react-native-webview": "13.12.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
Hey this is gonna be kinda lengthy. This is the dashboard UI and chart logic, but the calendar is unfinished and it hasn't been ported to the provider side. The full chart side should work now at least.

To test, use some set up patient accounts and navigate to March:
examplepatient3@email.com, examplepassword
examplepatient4@email.com, examplepassword

Things implemented:
- Dashboard chart visualizing weight record.
  - Pulls weight record and patient notes from db, creates chart using weight record.
  - Chart renders a specific month of weight records, has a month header to allow user to switch to prev/next month. Chart handles filtering the complete weight record for the month determined. Defaults to current month.
- Chart has tappable points that sends selected day back to DashboardScreen. Screen then finds the requisite weight record and notes and displays them in the bottom notes section. The notes section is a scrollview because I think we're adding more to it later.

TODO:
- Implement calendar. it's already rendered and included, but has no functionality. need to do stuff like add a border, let it take and parse weight record, add dot/markers underneath dates for things like missed dates or notes.
- ~~port over to provider. Need to remove some react-native stuff and use a separate icon library since vite doesn't have expo stuff.~~ Finished. will save for next PR.
- Rewrite enter data to not allow or rewrite weight records on the same day.

Should I be doing the notes section too? Should patients be able to set their own notes or is it only the provider that sets notes for a patient? Additionally, should notes be displayed on all days or just the timestamp day? Should patients be seeing the notes in the dashboard at all?