### PR TITLE
Auth fixes

### DIFF
--- a/dww_backend/.ebextensions/clearsessions.config
+++ b/dww_backend/.ebextensions/clearsessions.config
@@ -1,0 +1,12 @@
+container_commands:
+  01_clearsessions:
+    command: "python manage.py clearsessions"
+
+files:
+  "/etc/cron.d/clearsessions":
+    mode: "0644"
+    owner: root
+    group: root
+    content: |
+      # Run clearsessions every day at 4:00am 
+      0 4 * * * root cd /var/app/current && /var/app/venv/*/bin/python manage.py clearsessions

--- a/dww_backend/core/settings.py
+++ b/dww_backend/core/settings.py
@@ -13,7 +13,6 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 from pathlib import Path
 from dotenv import load_dotenv 
 import os 
-from corsheaders.defaults import default_headers
 from datetime import timedelta
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -35,6 +34,7 @@ DEBUG = DJANGO_ENV == "development"
 # the domain that the browser will send the cookie back to. Will also send to subdomains of this domain. 
 # defaults to sending only to the exact domain where the cookie originated from 
 SESSION_COOKIE_DOMAIN = None
+SESSION_COOKIE_AGE = 60*60*24*7  # provider sessions expire after 1 week
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS").split(",")
 

--- a/dww_backend/core/settings.py
+++ b/dww_backend/core/settings.py
@@ -35,10 +35,9 @@ DEBUG = DJANGO_ENV == "development"
 # defaults to sending only to the exact domain where the cookie originated from 
 SESSION_COOKIE_DOMAIN = None
 SESSION_COOKIE_AGE = 60*60*24*7  # provider sessions expire after 1 week
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True  # better physical/workplace security 
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS").split(",")
-
-# Application definition
 
 INSTALLED_APPS = [
     "django.contrib.admin",

--- a/dww_provider/src/components/AuthContext.tsx
+++ b/dww_provider/src/components/AuthContext.tsx
@@ -10,15 +10,10 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
-    localStorage.getItem('authToken') ? true : false
-  );
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false); 
 
   const login = () => setIsAuthenticated(true);
-  const logout = () => {
-    setIsAuthenticated(false);
-    localStorage.removeItem('authToken');
-  };
+  const logout = () => setIsAuthenticated(false); 
   const getCSRFToken = async () => {
     const response = await fetch(`${process.env.VITE_PUBLIC_DEV_SERVER_URL}/get-csrf-token/`, {
       credentials: 'include', 

--- a/dww_provider/src/components/Navbar.tsx
+++ b/dww_provider/src/components/Navbar.tsx
@@ -22,9 +22,7 @@ const Navbar: React.FC = () => {
       if (response.ok) {
         const data = await response.json();
         console.log(data.message);
-
         logout();
-
         navigate('/login');
       } else {
         console.error('Failed to log out');


### PR DESCRIPTION
It turns out sessions *do* get deleted from the database when the user logs out, but not if the session expires or browser is closed without explicitly logging out. This can lead to expired sessions remaining in the database. `python manage.py clearsessions` clears any session cookies and associated data that are past their expiration. The `clearsessions.config` tells AWS EB to set up a recurring task that runs Django's `clearsessions` script once per day at 4:00am. This will prevent the database from bloating over time, especially with a large number of users. 

Once at the end of last sprint, I got an error where logging out on the patient interface triggered an infinite loop of error alerts. I thought there was an issue with expired refresh tokens but I haven't been able to replicate the issue, so no changes there. If you happen to experience this issue please let me know. 