### PR TITLE
Patient dashboard

### DIFF
--- a/dww_patient/app/home/DashboardScreen.tsx
+++ b/dww_patient/app/home/DashboardScreen.tsx
@@ -123,7 +123,7 @@ const DashboardScreen = () => {
       </View>
 
       <View style={styles.chartContainer}>
-        {chart === 'chart' ? <Chart weightRecord={weightRecord} onDataPointSelect={handleDataPointSelect}/> : <Calendar/>}
+        {chart === 'chart' ? <Chart weightRecord={weightRecord} onDataPointSelect={handleDataPointSelect}/> : <Calendar onDataPointSelect={handleDataPointSelect}/>}
       </View>
 
       <ScrollView style={styles.noteContainer}>

--- a/dww_patient/app/home/DashboardScreen.tsx
+++ b/dww_patient/app/home/DashboardScreen.tsx
@@ -123,7 +123,7 @@ const DashboardScreen = () => {
       </View>
 
       <View style={styles.chartContainer}>
-        {chart === 'chart' ? <Chart weightRecord={weightRecord} onDataPointSelect={handleDataPointSelect}/> : <Calendar onDataPointSelect={handleDataPointSelect}/>}
+        {chart === 'chart' ? <Chart weightRecord={weightRecord} onDataPointSelect={handleDataPointSelect}/> : <Calendar weightRecord={weightRecord} onDataPointSelect={handleDataPointSelect}/>}
       </View>
 
       <ScrollView style={styles.noteContainer}>

--- a/dww_patient/assets/components/Calendar.tsx
+++ b/dww_patient/assets/components/Calendar.tsx
@@ -1,9 +1,17 @@
 import React, { useState } from 'react';
-import { View, LayoutChangeEvent } from 'react-native';
-import Svg, { Rect, Text, G } from 'react-native-svg';
+import { View, LayoutChangeEvent, TouchableOpacity, StyleSheet, Text } from 'react-native';
+import Svg, { Text as SvgText, Rect, G } from 'react-native-svg';
+import Ionicons from '@expo/vector-icons/Ionicons'; 
 
-const Calendar = () => {
+type CalendarProps = {
+  onDataPointSelect: (selectedData: {
+    day: Date;
+  }) => void;
+};
+
+const Calendar = ({ onDataPointSelect }: CalendarProps) => {
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [selectedMonth, setSelectedMonth] = useState(new Date());
   const CELL_SIZE = dimensions.width / 7;
   const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   
@@ -17,6 +25,18 @@ const Calendar = () => {
     const { width, height } = event.nativeEvent.layout;
     setDimensions({ width, height });
   };
+
+  const handleNextMonth = () => {
+    let nextMonth = new Date(selectedMonth);
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    setSelectedMonth(nextMonth); 
+  }
+
+  const handlePrevMonth = () => {
+    let nextMonth = new Date(selectedMonth);
+    nextMonth.setMonth(nextMonth.getMonth() - 1); 
+    setSelectedMonth(nextMonth); 
+  }
 
   const grid = [];
   let dayCounter = 1;
@@ -38,50 +58,91 @@ const Calendar = () => {
   }
 
   return (
-    <View style={{ flex: 1 }} onLayout={onLayout}>
-      <Svg width={dimensions.width} height={dimensions.height} viewBox={`0 0 ${dimensions.width} ${dimensions.height}`} preserveAspectRatio="xMinYMin meet">
-        <G>
-          {DAYS.map((day, index) => (
-            <Text
-              key={day}
-              x={index * CELL_SIZE + CELL_SIZE / 2}
-              y={CELL_SIZE / 2}
-              textAnchor="middle"
-              alignmentBaseline="central"
-              fill="#7B5CB8"
-              fontSize={14}
-            >
-              {day}
-            </Text>
-          ))}
-        </G>
+    <View style={{ flex: 1 }}>
 
-        {grid.map((cell, index) => (
-          <G key={index}>
-            <Rect
-              x={cell.x}
-              y={cell.y}
-              width={CELL_SIZE}
-              height={CELL_SIZE}
-              fill="white"
-              stroke="#F0F0F0"
-              strokeWidth={1}
-            />
-            <Text
-              x={cell.x + CELL_SIZE / 2}
-              y={cell.y + CELL_SIZE / 2}
-              textAnchor="middle"
-              alignmentBaseline="central"
-              fill={cell.date === today.getDate() ? '#7B5CB8' : '#333'}
-              fontWeight={cell.date === today.getDate() ? 'bold' : 'normal'}
-            >
-              {cell.date}
-            </Text>
+      <View style={styles.monthHeader}>
+        <TouchableOpacity onPress={handlePrevMonth}>
+          <Ionicons name="chevron-back" size={24} color="#7B5CB8" />
+        </TouchableOpacity>
+        
+        <Text style={styles.monthText}>
+          {selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
+        </Text>
+        
+        <TouchableOpacity onPress={handleNextMonth}>
+          <Ionicons name="chevron-forward" size={24} color="#7B5CB8" />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.chartContainer} onLayout={onLayout}>
+        <Svg width={dimensions.width} height={dimensions.height}>
+          <G>
+            {DAYS.map((day, index) => (
+              <SvgText
+                key={day}
+                x={index * CELL_SIZE + CELL_SIZE / 2}
+                y={CELL_SIZE / 2}
+                textAnchor="middle"
+                alignmentBaseline="central"
+                fill="#7B5CB8"
+                fontSize={14}
+              >
+                {day}
+              </SvgText>
+            ))}
           </G>
-        ))}
-      </Svg>
+
+          {grid.map((cell, index) => (
+            <G key={index}>
+              <Rect
+                x={cell.x}
+                y={cell.y}
+                width={CELL_SIZE}
+                height={CELL_SIZE}
+                fill="white"
+                stroke="#F0F0F0"
+                strokeWidth={1}
+              />
+              <SvgText
+                x={cell.x + CELL_SIZE / 2}
+                y={cell.y + CELL_SIZE / 2}
+                textAnchor="middle"
+                alignmentBaseline="central"
+                fill={cell.date === today.getDate() ? '#7B5CB8' : '#333'}
+                fontWeight={cell.date === today.getDate() ? 'bold' : 'normal'}
+              >
+                {cell.date}
+              </SvgText>
+            </G>
+          ))}
+        </Svg>
+      </View>
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  monthHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 5,
+    borderColor: '#7B5CB8',
+    borderWidth: 1,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+  },
+  monthText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#4f3582',
+  },
+  chartContainer: {
+    borderColor: '#7B5CB8',
+    borderWidth: 1,
+    flex: 1,
+  },
+});
 
 export default Calendar;

--- a/dww_patient/assets/components/Calendar.tsx
+++ b/dww_patient/assets/components/Calendar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { View, LayoutChangeEvent, TouchableOpacity, StyleSheet, Text } from 'react-native';
-import Svg, { Text as SvgText, Rect, G } from 'react-native-svg';
+import Svg, { Text as SvgText, Rect, G, Circle } from 'react-native-svg';
 import Ionicons from '@expo/vector-icons/Ionicons'; 
 
 type CalendarProps = {
@@ -17,7 +17,6 @@ type WeightRecord = {
   timestamp: Date,
   weight: number,
 }
-
 
 const Calendar = ({ weightRecord, onDataPointSelect }: CalendarProps) => {
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -74,6 +73,7 @@ const Calendar = ({ weightRecord, onDataPointSelect }: CalendarProps) => {
         x: col * CELL_WIDTH + MARGIN,
         y: row * CELL_HEIGHT + CELL_HEIGHT, 
         timestamp: date ? new Date(year, month, date) : null,
+        hasWeightRecord: date ? selectedMonthRecord.some(record => record.timestamp.getDate() === date) : false,
       });
 
       if (!isEmpty) dayCounter++;
@@ -114,7 +114,6 @@ const Calendar = ({ weightRecord, onDataPointSelect }: CalendarProps) => {
               </SvgText>
             ))}
           </G>
-
           {grid.map((cell, index) => (
             <G key={index}>
               <Rect
@@ -132,16 +131,38 @@ const Calendar = ({ weightRecord, onDataPointSelect }: CalendarProps) => {
                   }
                 }}
               />
+              {cell.timestamp?.getTime() === selectedDay.getTime() && (
+                <Circle
+                  cx={cell.x + CELL_WIDTH / 2}
+                  cy={cell.y + CELL_HEIGHT / 2}
+                  r={12}
+                  fill="#7B5CB8"
+                />
+              )}
               <SvgText
                 x={cell.x + CELL_WIDTH / 2}
                 y={cell.y + CELL_HEIGHT / 2}
                 textAnchor="middle"
                 alignmentBaseline="central"
-                fill={cell.timestamp?.getTime() === selectedDay.getTime() ? '#7B5CB8' : '#333'}
+                fill={cell.timestamp?.getTime() === selectedDay.getTime() ? 'white' : '#333'}
                 fontWeight={cell.timestamp?.getTime() === selectedDay.getTime() ? 'bold' : 'normal'}
               >
                 {cell.timestamp?.getDate()}
               </SvgText>
+              {cell.hasWeightRecord && cell.timestamp?.getTime() != selectedDay.getTime() && (
+                <View style={styles.iconWrapper}>
+                  <Ionicons
+                    name="checkmark-sharp"
+                    size={12}
+                    color="#4f3582"
+                    style={{
+                      position: 'absolute',
+                      top: cell.y + CELL_HEIGHT - 16,
+                      left: cell.x + (CELL_WIDTH / 2) - 6,
+                    }}
+                  />
+                </View> 
+              )}
             </G>
           ))}
         </Svg>
@@ -171,6 +192,9 @@ const styles = StyleSheet.create({
     borderColor: '#7B5CB8',
     borderWidth: 1,
     flex: 1,
+  },
+  iconWrapper: {
+    position: 'absolute',
   },
 });
 

--- a/dww_provider/package-lock.json
+++ b/dww_provider/package-lock.json
@@ -2904,6 +2904,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
       "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }

--- a/dww_provider/src/components/Chart.tsx
+++ b/dww_provider/src/components/Chart.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
 
 type ChartProps = {
-  weightRecord: Array<{ //weight data to draw chart
+  weightRecord: Array<{
     timestamp: Date;
     weight: number;
   }>;
-  onDataPointSelect: (selectedData: { //function to interact with selected days in screen
+  onDataPointSelect: (selectedData: { 
     day: Date;
   }) => void;
 };
@@ -25,28 +25,26 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
 
   const handleNextMonth = () => {
     let nextMonth = new Date(selectedMonth);
-    nextMonth.setMonth(nextMonth.getMonth() + 1); // cant do this in one-liner because .setMonth returns milliseconds and not a Date object (WHYYY)
-    setSelectedMonth(nextMonth); //we need to do setSelectedMonth to change state and re-render component, but we cant do one-liner because of the above.
+    nextMonth.setMonth(nextMonth.getMonth() + 1); 
+    setSelectedMonth(nextMonth); 
   }
 
   const handlePrevMonth = () => {
     let nextMonth = new Date(selectedMonth);
-    nextMonth.setMonth(nextMonth.getMonth() - 1); // x2
-    setSelectedMonth(nextMonth); //cant do setState( new Date(date.setMonth + 1) ) because it recalculates it a second time in UTC and add/removes excess hours. This would cause issues if the timestamp is near midnight.
+    nextMonth.setMonth(nextMonth.getMonth() - 1); 
+    setSelectedMonth(nextMonth); 
   }
 
-  //calc x coord for where a day should be.
-  // `day / days in month` for an 'index scale', like 1/31. Then multiply by chart width - 2margin to get where it should be in the graph. Margins included to give space for axis label
+  //point placement
   const xScale = (day: Date) => {
     return ((day.getDate()) / (new Date(selectedMonth.getFullYear(), selectedMonth.getMonth() + 1, 0).getDate())) * (dimensions.width - MARGIN * 2) + MARGIN;
   };
 
-  //calc y coord for where height shoud be scaled to. Similar theory to xScale.
   const yScale = (weight: number) => {
     return dimensions.height - MARGIN - ((weight - minWeight) / (maxWeight - minWeight)) * (dimensions.height - MARGIN * 2);
   };
 
-  //generate 7 grid lines, range / 6 represents the spaces inbetween (grid lines - 1)
+  //gridline placement
   const generateYAxisGrid = () => {
     const range = maxWeight - minWeight;
     return Array.from({ length: 7 }, (_, i) => minWeight + i * (range / 6));
@@ -56,7 +54,6 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
     return Array.from({ length: new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate() }, (_, i) => i + 1);
   };
 
-  //selectedMonthRecord = filtered weight record for selectedMonth.
   useEffect(() => {
     const filteredData = weightRecord.filter((point) => {
       return (
@@ -77,22 +74,16 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
   
     updateDimensions();
   
-    // Add event listener to update dimensions on window resize
     window.addEventListener('resize', updateDimensions);
   
-    // Clean up event listener on component unmount
     return () => window.removeEventListener('resize', updateDimensions);
   }, []);
 
-  //some calculations used for yScale and yGrid
-  //basically it pads the y-dimension by a constant value of +-5lbs alongside the range of the patient's weight record, scaling the y-axis in case the patient sees a dramatic weight change
-  //theoretically this makes it so the graph doesn't look exceedingly goofy if the range of the patient's weight change is like >=10 lbs in one month. the line always takes the inner 1/3 of graph space
   const range = Math.max(...selectedMonthRecord.map(d => d.weight)) - Math.min(...selectedMonthRecord.map(d => d.weight));
   const padding = range + 5;
   const minWeight = Math.min(...selectedMonthRecord.map(d => d.weight)) - padding;
   const maxWeight = Math.max(...selectedMonthRecord.map(d => d.weight)) + padding;
 
-  //draw path, 'M' to move to first point location, then 'L' to move while drawing the line onwards.
   //TODO: special behavior for missing days while drawing?
   let path = '';
   selectedMonthRecord.forEach((point, index) => {
@@ -103,20 +94,20 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
     }
   });
 
-  // draw axes (line x2), gridlines, line (path), then interactable points (circles)
+  //draw axes (line x2), gridlines (generated lines and text), line (path), then interactable points (circles)
   return (
     <div style={{ flex: 1 }}>
 
       <div style={styles.monthHeader}>
-        <button onClick={handlePrevMonth}>
+        <button onClick={handlePrevMonth} style={{ backgroundColor: '#7B5CB8' }}>
             &#9664;
         </button>
         
-        <text style={styles.monthText}>
+        <text style={{...styles.monthText, userSelect: 'none', pointerEvents: 'none'}}>
           {selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })}
         </text>
         
-        <button onClick={handleNextMonth}>
+        <button onClick={handleNextMonth} style={{ backgroundColor: '#7B5CB8' }}>
             &#9654;
         </button>
       </div>
@@ -161,6 +152,7 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
                   textAnchor="end"
                   fill="#666"
                   fontSize="10"
+                  style={{ userSelect: 'none', pointerEvents: 'none' }}
                 >
                   {Math.round(gridValue)}
                 </text>
@@ -190,6 +182,7 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
                     textAnchor="middle"
                     fill="#666"
                     fontSize="10"
+                    style={{ userSelect: 'none', pointerEvents: 'none' }}
                   >
                     {`${selectedMonth.getMonth() + 1}/${day}`}
                   </text>

--- a/dww_provider/src/pages/PatientDetails.tsx
+++ b/dww_provider/src/pages/PatientDetails.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styles from "../styles/PatientDetails.module.css";
 import Chart from '../components/Chart';
+import Calendar from '../components/Calendar';
 
 type WeightRecord = {
   weight: number;
@@ -34,6 +35,7 @@ const PatientDetails: React.FC = () => {
     weight?: number;
     notes?: string;
   } | null>({ day: new Date() });
+  const [chart, setChart] = useState('chart');
   const navigate = useNavigate(); 
 
   const getCSRFToken = async () => {
@@ -141,15 +143,46 @@ const PatientDetails: React.FC = () => {
 
         <div className={styles.weight_history}>
           <h2 className={styles.weight_history_title}>Weight History</h2>
+          <div className={styles.chart_slider_container}>
+            <button
+              className={styles.chart_left_button}
+              style={{
+                backgroundColor: chart === 'chart' ? '#7B5CB8' : 'white',
+                color: chart === 'chart' ? 'white' : 'gray'
+              }}
+              onClick={() => setChart('chart')}
+            >
+              Chart
+            </button>
+            <button
+              className={styles.chart_right_button}
+              style={{
+                backgroundColor: chart === 'calendar' ? '#7B5CB8' : 'white',
+                color: chart === 'calendar' ? 'white' : 'gray'
+              }}
+              onClick={() => setChart('calendar')}
+            >
+              Calendar
+            </button>
+          </div>
           {weightHistory.length > 0 ? (
             <div className={styles.chart_container}>
-              <Chart 
-                weightRecord={weightHistory.map(r => ({
-                  timestamp: new Date(r.timestamp),
-                  weight: r.weight
-                }))}
-                onDataPointSelect={handleDataPointSelect}
-              />
+              {chart === 'chart' ? 
+                <Chart
+                  weightRecord={weightHistory.map(r => ({
+                    timestamp: new Date(r.timestamp),
+                    weight: r.weight
+                  }))}
+                  onDataPointSelect={handleDataPointSelect}
+                /> : 
+                <Calendar
+                  weightRecord={weightHistory.map(r => ({
+                    timestamp: new Date(r.timestamp),
+                    weight: r.weight
+                  }))}
+                  onDataPointSelect={handleDataPointSelect}
+                />
+              }
             </div>
           ) : (
             <p>No weight history available.</p>

--- a/dww_provider/src/styles/PatientDetails.module.css
+++ b/dww_provider/src/styles/PatientDetails.module.css
@@ -30,6 +30,34 @@
     font-weight: bold;
 }
 
+.chart_slider_container {
+    padding: 10px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    background-color: white;
+}
+
+.chart_left_button {
+    padding: 12px;
+    border-top-left-radius: 20px;
+    border-bottom-left-radius: 20px;
+    max-width: 120px;
+    min-width: 100px;
+    align-items: center;
+    border: 1px solid #7B5CB8;
+}
+
+.chart_right_button {
+    padding: 12px;
+    border-top-right-radius: 20px;
+    border-bottom-right-radius: 20px;
+    max-width: 120px;
+    min-width: 100px;
+    align-items: center;
+    border: 1px solid #7B5CB8;
+}
+
 .weight-history {
     margin-top: 20px;
     padding: 15px;


### PR DESCRIPTION
Features:
- Calendar, both on patient and ported to provider.
  - Dynamically renders each month, days are accurate to actual name-days (Wednesday, Tuesday, Friday, whatever)
  - Marks a checkmark underneath days with an associated weight record (good job!)
  - Selected day is circled in purple
- Miscellaneous
  - changed next/previous month buttons of provider charts to purple. Unfortunately this got rid of the touchable opacity part of the buttons. Unsure and unwilling to fix. I think its better than them being blue.
  - Added toggle between chart/calendar.

TODO:
- Chart/Calendar are different sizes on provider. I'm genuinely not sure how, since they should conform to flexbox but toggling between the two slightly shifts the size of the details viewbox to fit. I'm unsure if the view is expanding or shrinking.

gonna add trendline next. May also handle displaying multiple weight records on the Notes section, unless you want to do that Jonathan.