### PR TITLE
Aggregate same-day weight records

### DIFF
--- a/dww_patient/app/home/DashboardScreen.tsx
+++ b/dww_patient/app/home/DashboardScreen.tsx
@@ -21,11 +21,7 @@ const DashboardScreen = () => {
   const navigation = useNavigation<HomeTabScreenProps<'Dashboard'>['navigation']>();
   const { accessToken, refreshAccessToken, logout } = useAuth();
   const [chart, setChart] = useState('chart');
-  const [selectedDay, setSelectedDay] = useState<{
-    day: Date;
-    weight?: number;
-    notes?: string;
-  } | null>({ day: new Date() });
+  const [selectedDay, setSelectedDay] = useState(new Date());
   const [weightRecord, setWeightRecord] = useState<WeightRecord[]>([]);
   const [patientNotes, setPatientNotes] = useState<PatientNote[]>([]);
 
@@ -89,6 +85,10 @@ const DashboardScreen = () => {
     }
   }
 
+  const handleDataPointSelect = (day: Date) => {
+    setSelectedDay(day);
+  };
+/*
   const handleDataPointSelect = (selectedData: { day: Date }) => {
     setSelectedDay({
       day: selectedData.day,
@@ -98,7 +98,7 @@ const DashboardScreen = () => {
         .map(note => note.note).join('\n') || 'No notes for this day',
     });
   };
-
+*/
   useFocusEffect(
     useCallback(() => {
       fetchWeightRecord();
@@ -133,7 +133,7 @@ const DashboardScreen = () => {
           <View style={styles.noteSection}>
             <Text style={styles.noteLabel}>Date:</Text>
             <Text style={styles.noteValue}>
-              {selectedDay.day.toLocaleDateString('en-US', {
+              {selectedDay.toLocaleDateString('en-US', {
                 weekday: 'long',
                 year: 'numeric',
                 month: 'long',
@@ -142,12 +142,35 @@ const DashboardScreen = () => {
             </Text>
           </View>
 
-          {selectedDay.weight && (
+          {selectedDay && (
             <View style={styles.noteSection}>
               <Text style={styles.noteLabel}>Weight Recorded:</Text>
-              <Text style={styles.noteValue}>
-                {selectedDay.weight} lbs
-              </Text>
+              {weightRecord
+                .filter(record => 
+                  record.timestamp.getFullYear() === selectedDay.getFullYear() &&
+                  record.timestamp.getMonth() === selectedDay.getMonth() &&
+                  record.timestamp.getDate() === selectedDay.getDate()
+                )
+                .map((record, index) => (
+                  <View key={index} style={styles.noteItem}>
+                    <Text style={styles.noteValue}>
+                      {record.weight} lbs
+                    </Text>
+                    <Text style={styles.noteTime}>
+                      {record.timestamp.toLocaleTimeString('en-US', {
+                        hour: '2-digit',
+                        minute: '2-digit'
+                      })}
+                    </Text>
+                  </View>
+                ))}
+              {!weightRecord.some(record => 
+                record.timestamp.getFullYear() === selectedDay.getFullYear() &&
+                record.timestamp.getMonth() === selectedDay.getMonth() &&
+                record.timestamp.getDate() === selectedDay.getDate()
+              ) && (
+                <Text style={styles.noNotesText}>No weight records for this day</Text>
+              )}
             </View>
           )}
 
@@ -155,7 +178,7 @@ const DashboardScreen = () => {
             <Text style={styles.noteLabel}>Notes:</Text>
             {patientNotes
               .filter(note => 
-                note.timestamp.toDateString() === selectedDay.day.toDateString()
+                note.timestamp.toDateString() === selectedDay.toDateString()
               )
               .map((note, index) => (
                 <View key={index} style={styles.noteItem}>
@@ -170,7 +193,7 @@ const DashboardScreen = () => {
               ))}
             
             {!patientNotes.some(note => 
-              note.timestamp.toDateString() === selectedDay.day.toDateString()
+              note.timestamp.toDateString() === selectedDay.toDateString()
             ) && (
               <Text style={styles.noNotesText}>No notes for this day</Text>
             )}

--- a/dww_patient/app/home/DashboardScreen.tsx
+++ b/dww_patient/app/home/DashboardScreen.tsx
@@ -142,37 +142,35 @@ const DashboardScreen = () => {
             </Text>
           </View>
 
-          {selectedDay && (
-            <View style={styles.noteSection}>
-              <Text style={styles.noteLabel}>Weight Recorded:</Text>
-              {weightRecord
-                .filter(record => 
-                  record.timestamp.getFullYear() === selectedDay.getFullYear() &&
-                  record.timestamp.getMonth() === selectedDay.getMonth() &&
-                  record.timestamp.getDate() === selectedDay.getDate()
-                )
-                .map((record, index) => (
-                  <View key={index} style={styles.noteItem}>
-                    <Text style={styles.noteValue}>
-                      {record.weight} lbs
-                    </Text>
-                    <Text style={styles.noteTime}>
-                      {record.timestamp.toLocaleTimeString('en-US', {
-                        hour: '2-digit',
-                        minute: '2-digit'
-                      })}
-                    </Text>
-                  </View>
-                ))}
-              {!weightRecord.some(record => 
+          <View style={styles.noteSection}>
+            <Text style={styles.noteLabel}>Weight Recorded:</Text>
+            {weightRecord
+              .filter(record => 
                 record.timestamp.getFullYear() === selectedDay.getFullYear() &&
                 record.timestamp.getMonth() === selectedDay.getMonth() &&
                 record.timestamp.getDate() === selectedDay.getDate()
-              ) && (
-                <Text style={styles.noNotesText}>No weight records for this day</Text>
-              )}
-            </View>
-          )}
+              )
+              .map((record, index) => (
+                <View key={index} style={styles.noteItem}>
+                  <Text style={styles.noteValue}>
+                    {record.weight} lbs
+                  </Text>
+                  <Text style={styles.noteTime}>
+                    {record.timestamp.toLocaleTimeString('en-US', {
+                      hour: '2-digit',
+                      minute: '2-digit'
+                    })}
+                  </Text>
+                </View>
+              ))}
+            {!weightRecord.some(record => 
+              record.timestamp.getFullYear() === selectedDay.getFullYear() &&
+              record.timestamp.getMonth() === selectedDay.getMonth() &&
+              record.timestamp.getDate() === selectedDay.getDate()
+            ) && (
+              <Text style={styles.noText}>No weight records for this day</Text>
+            )}
+          </View>
 
           <View style={styles.noteSection}>
             <Text style={styles.noteLabel}>Notes:</Text>
@@ -195,7 +193,7 @@ const DashboardScreen = () => {
             {!patientNotes.some(note => 
               note.timestamp.toDateString() === selectedDay.toDateString()
             ) && (
-              <Text style={styles.noNotesText}>No notes for this day</Text>
+              <Text style={styles.noText}>No notes for this day</Text>
             )}
           </View>
         </View>
@@ -299,7 +297,7 @@ const styles = StyleSheet.create({
     color: '#666',
     marginTop: 4,
   },
-  noNotesText: {
+  noText: {
     fontStyle: 'italic',
     color: '#999',
     textAlign: 'center',

--- a/dww_patient/assets/components/Calendar.tsx
+++ b/dww_patient/assets/components/Calendar.tsx
@@ -8,9 +8,7 @@ type CalendarProps = {
     timestamp: Date;
     weight: number;
   }>;
-  onDataPointSelect: (selectedData: {
-    day: Date;
-  }) => void;
+  onDataPointSelect: (day: Date) => void;
 };
 
 type WeightRecord = {
@@ -127,7 +125,7 @@ const Calendar = ({ weightRecord, onDataPointSelect }: CalendarProps) => {
                 onPress={() => { 
                   if (cell.timestamp) {
                     setSelectedDay(cell.timestamp); 
-                    onDataPointSelect({ day: cell.timestamp }); 
+                    onDataPointSelect(cell.timestamp); 
                   }
                 }}
               />

--- a/dww_patient/assets/components/Chart.tsx
+++ b/dww_patient/assets/components/Chart.tsx
@@ -8,9 +8,7 @@ type ChartProps = {
     timestamp: Date;
     weight: number;
   }>;
-  onDataPointSelect: (selectedData: {
-    day: Date;
-  }) => void;
+  onDataPointSelect: (day: Date) => void;
 };
 
 type WeightRecord = {
@@ -62,13 +60,31 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
   };
 
   useEffect(() => {
-    const filteredData = weightRecord.filter((point) => {
+    let monthlyData = weightRecord.filter((point) => {
       return (
         point.timestamp.getFullYear() === selectedMonth.getFullYear() &&
         point.timestamp.getMonth() === selectedMonth.getMonth()
       );
     });
-    setSelectedMonthRecord(filteredData);
+    const aggregatedData = monthlyData.reduce((acc: { [key: string]: { timestamp: Date, weight: number, count: number } }, point) => {
+      const dateKey = point.timestamp.toDateString();
+      if (!acc[dateKey]) {
+        acc[dateKey] = { ...point, weight: 0, count: 0 };
+      }
+      acc[dateKey].weight += Number(point.weight);
+      acc[dateKey].count += 1;
+      return acc;
+    }, {});
+  
+    const result = Object.keys(aggregatedData).map((dateKey) => {
+      const { timestamp, weight, count } = aggregatedData[dateKey];
+      return {
+        timestamp,
+        weight: weight / count,
+      };
+    }).sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  
+    setSelectedMonthRecord(result);
   }, [selectedMonth, weightRecord]);
 
   const range = Math.max(...selectedMonthRecord.map(d => d.weight)) - Math.min(...selectedMonthRecord.map(d => d.weight));
@@ -201,7 +217,7 @@ const Chart = ({ weightRecord, onDataPointSelect }: ChartProps) => {
                   cy={y}
                   r={isSelected ? "8" : "6"}
                   fill={isSelected ? "#4f3582" : "#7B5CB8"}
-                  onPress={() => { setSelectedDay(point.timestamp); onDataPointSelect({ day: point.timestamp }); }}
+                  onPress={() => { setSelectedDay(point.timestamp); onDataPointSelect(point.timestamp); }}
                 />
               </G>
             );

--- a/dww_provider/src/components/Calendar.tsx
+++ b/dww_provider/src/components/Calendar.tsx
@@ -5,9 +5,7 @@ type CalendarProps = {
     timestamp: Date;
     weight: number;
   }>;
-  onDataPointSelect: (selectedData: {
-    day: Date;
-  }) => void;
+  onDataPointSelect: (day: Date) => void;
 };
 
 type WeightRecord = {
@@ -136,7 +134,7 @@ const Calendar = ({ weightRecord, onDataPointSelect }: CalendarProps) => {
                 onClick={() => { 
                   if (cell.timestamp) {
                     setSelectedDay(cell.timestamp); 
-                    onDataPointSelect({ day: cell.timestamp }); 
+                    onDataPointSelect(cell.timestamp); 
                   }
                 }}
               />

--- a/dww_provider/src/styles/PatientDetails.module.css
+++ b/dww_provider/src/styles/PatientDetails.module.css
@@ -95,6 +95,50 @@
     box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
 }
 
+.noteContent {
+    padding: 16px;
+  }
+  
+.noteSection {
+margin-bottom: 24px;
+border-bottom-width: 1px;
+border-bottom-color: #EEE;
+padding-bottom: 16px;
+}
+
+.noteLabel {
+font-size: 16px;
+font-weight: 600;
+color: #4f3582;
+margin-bottom: 8px;
+}
+
+.noteValue {
+font-size: 16px;
+color: #333;
+}
+
+.noteItem {
+background-color: #F5F9FF;
+border-radius: 8px;
+padding: 12px;
+margin-top: 10px;
+margin-bottom: 10px;
+display: flex;
+justify-content: space-between;
+}
+
+.noteText {
+font-size: 14px;
+color: #333;
+}
+
+.noteTime {
+font-size: 12px;
+color: #666;
+margin-top: 4px;
+}   
+  
 .button_container {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Small PR, only pushing this today because I edited the note section slightly so the Weight note section shows multiple weight records.

Features are very simple, all calculations occur in the component. When it filters out the weight records for the selected month, it filters weight records that exist on the same day and sum them and average them before removing the same-day weight records and adding the aggregated one. This is 'option 2'.

Unfortunately I couldn't figure out how to do this in-place so it just removes all the same-day records, adds the aggregated record, and then sorts the selectedMonthRecord by timestamp.

Afterwards I changed the note section stuff on DashboardScreen and PatientDetails to draw many weight records instead of the first one when showing the selectedDay weight records.

TODO:
- `DashboardScreen.tsx` has a scrollview, but `PatientDetails.tsx` does not. This means if there were fifty weight records on the same day the Provider UI would overflow. I am unsure what the React analogue for Native's ScrollView is. It looks like its just a CSS styling option, but I am rather unwilling to look at it because it hurts my head. As a sidenote, I apologize for the warcrimes I'm committing when translating things from Native to React. I'm admittedly not putting much thought into it as I should.

The trendline toggle is becoming a bit more of an issue than I expected, but it should be fully contained within `Chart.tsx` so it shouldn't affect any future PR's.