### PR TITLE
PatientDetails refactor

### DIFF
--- a/dww_provider/src/components/ChartCalendarViz.tsx
+++ b/dww_provider/src/components/ChartCalendarViz.tsx
@@ -18,7 +18,7 @@ const ChartCalendarViz: React.FC<ChartCalendarVizProps> = ({ weightHistory, onDa
   return (
     <div className={styles.weight_history}>
       <h2 className={styles.weight_history_title}>Weight History</h2>
-      <div className={styles.chart_slider_container}>
+      <div className={styles.chart_button_container}>
         <button
           className={styles.chart_left_button}
           style={{

--- a/dww_provider/src/components/ChartCalendarViz.tsx
+++ b/dww_provider/src/components/ChartCalendarViz.tsx
@@ -3,18 +3,11 @@ import { useState } from 'react';
 import Chart from './Chart';
 import Calendar from './Calendar';
 import styles from '../styles/ChartCalendarViz.module.css';
+import { WeightRecord, ChartCalendarVizProps } from '../utils/types'; 
 
-type WeightRecord = {
-  weight: number;
-  timestamp: string;
-};
 
-interface Props {
-  weightHistory: WeightRecord[];
-  onDataPointSelect: (day: Date) => void;
-}
 
-const ChartCalendarViz: React.FC<Props> = ({ weightHistory, onDataPointSelect }) => {
+const ChartCalendarViz: React.FC<ChartCalendarVizProps> = ({ weightHistory, onDataPointSelect }) => {
   const [chartView, setChartView] = useState<'chart' | 'calendar'>('chart');
 
   const formattedRecords = weightHistory.map(r => ({

--- a/dww_provider/src/components/ChartCalendarViz.tsx
+++ b/dww_provider/src/components/ChartCalendarViz.tsx
@@ -1,0 +1,65 @@
+
+import { useState } from 'react';
+import Chart from './Chart';
+import Calendar from './Calendar';
+import styles from '../styles/ChartCalendarViz.module.css';
+
+type WeightRecord = {
+  weight: number;
+  timestamp: string;
+};
+
+interface Props {
+  weightHistory: WeightRecord[];
+  onDataPointSelect: (day: Date) => void;
+}
+
+const ChartCalendarViz: React.FC<Props> = ({ weightHistory, onDataPointSelect }) => {
+  const [chartView, setChartView] = useState<'chart' | 'calendar'>('chart');
+
+  const formattedRecords = weightHistory.map(r => ({
+    timestamp: new Date(r.timestamp),
+    weight: r.weight,
+  }));
+
+  return (
+    <div className={styles.weight_history}>
+      <h2 className={styles.weight_history_title}>Weight History</h2>
+      <div className={styles.chart_slider_container}>
+        <button
+          className={styles.chart_left_button}
+          style={{
+            backgroundColor: chartView === 'chart' ? '#7B5CB8' : 'white',
+            color: chartView === 'chart' ? 'white' : 'gray'
+          }}
+          onClick={() => setChartView('chart')}
+        >
+          Chart
+        </button>
+        <button
+          className={styles.chart_right_button}
+          style={{
+            backgroundColor: chartView === 'calendar' ? '#7B5CB8' : 'white',
+            color: chartView === 'calendar' ? 'white' : 'gray'
+          }}
+          onClick={() => setChartView('calendar')}
+        >
+          Calendar
+        </button>
+      </div>
+      {formattedRecords.length > 0 ? (
+        <div className={styles.chart_container}>
+          {chartView === 'chart' ? (
+            <Chart weightRecord={formattedRecords} onDataPointSelect={onDataPointSelect} />
+          ) : (
+            <Calendar weightRecord={formattedRecords} onDataPointSelect={onDataPointSelect} />
+          )}
+        </div>
+      ) : (
+        <p>No weight history available.</p>
+      )}
+    </div>
+  );
+};
+
+export default ChartCalendarViz;

--- a/dww_provider/src/components/PatientInfoSection.tsx
+++ b/dww_provider/src/components/PatientInfoSection.tsx
@@ -5,7 +5,10 @@ import { PatientInfo, PatientInfoSectionProps } from '../utils/types';
 
 
 
-const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, csrfToken }) => {
+const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ 
+  patientInfo, csrfToken, email, latestWeight, weightLastUpdated 
+}) => {
+
   const [fields, setFields] = useState<PatientInfo>(patientInfo ?? {});
   const [isEditing, setIsEditing] = useState(false);
 
@@ -42,17 +45,24 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
   return (
     <div>
       <div className={styles.basicInfoHeader}>
-        <span>
-          <strong>Basic Information</strong>&nbsp; 
-          (last updated {fields.last_updated ? new Date(fields.last_updated).toLocaleDateString() : 'N/A'}):
-        </span>
+        <div>
+          <strong>Basic Information</strong> &nbsp;
+          <span className={styles.lastUpdatedText}>
+            (last updated {fields.last_updated ? new Date(fields.last_updated).toLocaleDateString() : 'N/A'})
+          </span>
+        </div>
         <span onClick={handleEditClick} className={styles.updateSaveText}>
           {isEditing ? 'Save' : 'Update'}
         </span>
       </div>
   
-      <div>
-        <strong>Date of Birth: </strong>
+      <div className={styles.infoRow}>
+        <strong>Email:</strong>
+        <span>{email}</span>
+      </div>
+  
+      <div className={styles.infoRow}>
+        <strong>Date of Birth:</strong>
         {isEditing ? (
           <input
             type="text"
@@ -66,12 +76,12 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             }}
           />
         ) : (
-          <span> {fields.date_of_birth || 'None'}</span>
+          <span>{fields.date_of_birth || 'None'}</span>
         )}
       </div>
   
-      <div>
-        <strong>Sex: </strong>
+      <div className={styles.infoRow}>
+        <strong>Sex:</strong>
         {isEditing ? (
           <select
             value={fields.sex || ''}
@@ -85,12 +95,12 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             <option value="O">Intersex / Other</option>
           </select>
         ) : (
-          <span> {fields.sex || 'None'}</span>
+          <span>{fields.sex || 'None'}</span>
         )}
       </div>
   
-      <div>
-        <strong>Height: </strong>
+      <div className={styles.infoRow}>
+        <strong>Height:</strong>
         {isEditing ? (
           <input
             type="number"
@@ -98,39 +108,54 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             onChange={(event) =>
               setFields((prev) => ({ ...prev, height: event.target.value }))
             }
-          /> 
+          />
         ) : (
           <span>{fields.height ? `${fields.height} cm` : 'None'}</span>
         )}
       </div>
   
-      <div>
-        <strong>Medications: </strong>
+      <div className={styles.infoRow}>
+        <strong>Medications:</strong>
         {isEditing ? (
-          <input
-            type="text"
+          <textarea
+            className={styles.medicationsTextarea}
             value={fields.medications || ''}
             onChange={(event) =>
               setFields((prev) => ({ ...prev, medications: event.target.value }))
             }
           />
         ) : (
-          <span> {fields.medications || 'None'}</span>
+          <span className={styles.textBlock}>{fields.medications || 'None'}</span>
         )}
       </div>
-  
-      <div>
-        <strong>Other Information: </strong>
+
+      <div className={styles.infoRow}>
+        <strong>Other Information:</strong>
         {isEditing ? (
-          <input
-            type="text"
+          <textarea 
+            className={styles.otherInfoTextarea}
             value={fields.other_info || ''}
             onChange={(event) =>
               setFields((prev) => ({ ...prev, other_info: event.target.value }))
             }
           />
         ) : (
-          <span> {fields.other_info || 'None'}</span>
+          <span className={styles.textBlock}>{fields.other_info || 'None'}</span>
+        )}
+      </div>
+  
+      <div className={styles.latestWeight}>
+        <strong>Latest Weight:</strong>&nbsp;
+        {latestWeight !== undefined ? (
+          <span>
+            {latestWeight} lbs &nbsp;&nbsp;
+            {weightLastUpdated && 
+              <span className={styles.lastUpdatedText}>
+                (last measured ${new Date(weightLastUpdated).toLocaleString()})`
+              </span>}
+          </span>
+        ) : (
+          <span>Not available</span>
         )}
       </div>
     </div>

--- a/dww_provider/src/components/PatientInfoSection.tsx
+++ b/dww_provider/src/components/PatientInfoSection.tsx
@@ -10,7 +10,7 @@ interface PatientInfo {
   height?: string;
   medications?: string;
   other_info?: string;
-  last_updated?: string; 
+  last_updated?: Date; 
 }
 
 interface PatientInfoSectionProps {
@@ -37,6 +37,12 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
           credentials: 'include', 
           body: JSON.stringify(request_fields)
         });
+
+        setFields((prev) => ({
+          ...prev,
+          last_updated: new Date(),
+        }));
+
         if (!response.ok) {
           console.error('Error updating patient field data');
         }
@@ -52,7 +58,7 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
       <div className={styles.basicInfoHeader}>
         <span>
           <strong>Basic Information</strong>&nbsp; 
-          (last updated {fields.last_updated ? new Date(fields.last_updated).toLocaleString() : 'N/A'}):
+          (last updated {fields.last_updated ? new Date(fields.last_updated).toLocaleDateString() : 'N/A'}):
         </span>
         <span onClick={handleEditClick} className={styles.updateSaveText}>
           {isEditing ? 'Save' : 'Update'}
@@ -74,7 +80,7 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             }}
           />
         ) : (
-          <span> {fields.date_of_birth || 'N/A'}</span>
+          <span> {fields.date_of_birth || 'None'}</span>
         )}
       </div>
   
@@ -93,7 +99,7 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             <option value="O">Intersex / Other</option>
           </select>
         ) : (
-          <span> {fields.sex || 'N/A'}</span>
+          <span> {fields.sex || 'None'}</span>
         )}
       </div>
   
@@ -108,7 +114,7 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             }
           /> 
         ) : (
-          <span> {fields.height || 'N/A'} cm</span>
+          <span>{fields.height ? `${fields.height} cm` : 'None'}</span>
         )}
       </div>
   
@@ -123,7 +129,7 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             }
           />
         ) : (
-          <span> {fields.medications || 'N/A'}</span>
+          <span> {fields.medications || 'None'}</span>
         )}
       </div>
   
@@ -138,7 +144,7 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, cs
             }
           />
         ) : (
-          <span> {fields.other_info || 'N/A'}</span>
+          <span> {fields.other_info || 'None'}</span>
         )}
       </div>
     </div>

--- a/dww_provider/src/components/PatientInfoSection.tsx
+++ b/dww_provider/src/components/PatientInfoSection.tsx
@@ -1,25 +1,8 @@
 
 import React, { useState } from 'react';
 import styles from '../styles/PatientInfoSection.module.css';
+import { PatientInfo, PatientInfoSectionProps } from '../utils/types'; 
 
-
-interface PatientInfo {
-  patient?: number; 
-  date_of_birth?: string;
-  sex?: string;
-  height?: string;
-  medications?: string;
-  other_info?: string;
-  last_updated?: Date; 
-}
-
-interface PatientInfoSectionProps {
-  patientInfo?: PatientInfo;
-  csrfToken: string;
-  email: string; 
-  latestWeight?: number; 
-  weightLastUpdated?: Date; 
-}
 
 
 const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({ patientInfo, csrfToken }) => {

--- a/dww_provider/src/components/PatientInfoSection.tsx
+++ b/dww_provider/src/components/PatientInfoSection.tsx
@@ -16,6 +16,9 @@ interface PatientInfo {
 interface PatientInfoSectionProps {
   patientInfo?: PatientInfo;
   csrfToken: string;
+  email: string; 
+  latestWeight?: number; 
+  weightLastUpdated?: Date; 
 }
 
 

--- a/dww_provider/src/components/PatientNotesSection.tsx
+++ b/dww_provider/src/components/PatientNotesSection.tsx
@@ -1,4 +1,3 @@
-// src/components/PatientNotesSection.tsx
 
 import { useState } from "react";
 import styles from "../styles/PatientDetails.module.css";

--- a/dww_provider/src/components/PatientNotesSection.tsx
+++ b/dww_provider/src/components/PatientNotesSection.tsx
@@ -1,0 +1,107 @@
+// src/components/PatientNotesSection.tsx
+
+import { useState } from "react";
+import styles from "../styles/PatientDetails.module.css";
+
+type WeightRecord = {
+  weight: number;
+  timestamp: string;
+};
+
+type PatientNote = {
+  timestamp: Date;
+  note: string;
+};
+
+type PatientNotesSectionProps = {
+  selectedDay: Date;
+  weightHistory?: WeightRecord[];
+  notes?: PatientNote[];
+  addNoteText: string;
+  setAddNoteText: (text: string) => void;
+  handleKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+};
+
+const PatientNotesSection: React.FC<PatientNotesSectionProps> = ({
+  selectedDay,
+  weightHistory = [],
+  notes = [],
+  addNoteText,
+  setAddNoteText,
+  handleKeyDown,
+}) => {
+  const weightRecordsForDay = weightHistory.filter((record) => {
+    const ts = new Date(record.timestamp);
+    return (
+      ts.getFullYear() === selectedDay.getFullYear() &&
+      ts.getMonth() === selectedDay.getMonth() &&
+      ts.getDate() === selectedDay.getDate()
+    );
+  });
+
+  const notesForDay = notes.filter(
+    (note) => note.timestamp.toDateString() === selectedDay.toDateString()
+  );
+
+  return (
+    <div className={styles.patient_info}>
+      <div className={styles.noteSection}>
+        <span className={styles.label}>Selected Day: </span>
+        {selectedDay.toLocaleDateString("en-US", {
+          weekday: "long",
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        })}
+      </div>
+
+      <div className={styles.noteSection}>
+        <span className={styles.label}>Weight Recorded: </span>
+        {weightRecordsForDay.length > 0 ? (
+          weightRecordsForDay.map((record, index) => (
+            <div key={index} className={styles.noteItem}>
+              <span className={styles.noteValue}>{record.weight} lbs</span>
+              <span className={styles.noteTime}>
+                {new Date(record.timestamp).toLocaleTimeString("en-US", {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+            </div>
+          ))
+        ) : (
+          <span>No weight records for this day</span>
+        )}
+      </div>
+
+      <div className={styles.noteSection}>
+        <span className={styles.label}>Notes: </span>
+        {notesForDay.length > 0 ? (
+          notesForDay.map((note, index) => (
+            <div key={index} className={styles.noteItem}>
+              <span className={styles.noteText}>{note.note}</span>
+              <span className={styles.noteTime}>
+                {note.timestamp.toLocaleTimeString("en-US", {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+            </div>
+          ))
+        ) : (
+          <span>No notes for this day</span>
+        )}
+      </div>
+
+      <textarea
+        value={addNoteText}
+        onChange={(e) => setAddNoteText(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className={styles.addNoteText}
+        placeholder="Type a note and press Enter..."
+      />
+    </div>
+  );
+};
+
+export default PatientNotesSection;

--- a/dww_provider/src/components/PatientNotesSection.tsx
+++ b/dww_provider/src/components/PatientNotesSection.tsx
@@ -1,25 +1,9 @@
 
 import { useState } from "react";
 import styles from "../styles/PatientDetails.module.css";
+import { PatientNotesSectionProps } from '../utils/types'; 
 
-type WeightRecord = {
-  weight: number;
-  timestamp: string;
-};
 
-type PatientNote = {
-  timestamp: Date;
-  note: string;
-};
-
-type PatientNotesSectionProps = {
-  selectedDay: Date;
-  weightHistory?: WeightRecord[];
-  notes?: PatientNote[];
-  addNoteText: string;
-  setAddNoteText: (text: string) => void;
-  handleKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-};
 
 const PatientNotesSection: React.FC<PatientNotesSectionProps> = ({
   selectedDay,
@@ -29,6 +13,7 @@ const PatientNotesSection: React.FC<PatientNotesSectionProps> = ({
   setAddNoteText,
   handleKeyDown,
 }) => {
+
   const weightRecordsForDay = weightHistory.filter((record) => {
     const ts = new Date(record.timestamp);
     return (

--- a/dww_provider/src/pages/PatientDetails.tsx
+++ b/dww_provider/src/pages/PatientDetails.tsx
@@ -22,7 +22,7 @@ interface PatientInfo {
   height?: string;
   medications?: string;
   other_info?: string;
-  last_updated?: string; 
+  last_updated?: Date; 
 }
 
 type Patient = {
@@ -145,6 +145,10 @@ const PatientDetails: React.FC = () => {
             ...note,
             timestamp: new Date(note.timestamp),
           }));
+        }
+
+        if (data.patient_info?.last_updated) {
+          data.patient_info.last_updated = new Date(data.patient_info.last_updated);
         }
 
         setPatient(data);

--- a/dww_provider/src/pages/PatientDetails.tsx
+++ b/dww_provider/src/pages/PatientDetails.tsx
@@ -108,88 +108,61 @@ const PatientDetails: React.FC = () => {
           credentials: "include",
         });
 
-        if (!res.ok) {
-          throw new Error(`HTTP error: ${res.status}`);
-        }
+        if (!res.ok) { throw new Error(`HTTP error: ${res.status}`); }
         const data = await res.json();
 
         // convert timestamps to Date objects
-        if (data.notes) {
-          data.notes = data.notes.map((note: PatientNote) => ({
-            ...note,
-            timestamp: new Date(note.timestamp),
-          }));
-        }
-        if (data.weight_history) {
-          data.weight_history = data.weight_history.map((record: any) => ({
-            ...record,
-            timestamp: new Date(record.timestamp),
-          }));
-        }
-        if (data.patient_info?.last_updated) {
-          data.patient_info.last_updated = new Date(data.patient_info.last_updated);
-        }
+        data.notes = data.notes.map((note: PatientNote) => ({
+          ...note,
+          timestamp: new Date(note.timestamp),
+        }));
+        data.weight_history = data.weight_history.map((record: any) => ({
+          ...record,
+          timestamp: new Date(record.timestamp),
+        }));
+        data.patient_info.last_updated = new Date(data.patient_info.last_updated);
 
         setPatient(data);
         console.log('patient data: ', data);           //         ----------------- temp 
-      } catch (err: any) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
+      } catch (err: any) { setError(err.message);
+      } finally { setLoading(false); }
     };
 
     getPatientData();
   }, [id, refresh]);
 
 
-  if (loading) {
-    return <div className={styles.loading}>Loading patient data…</div>;
-  }
-
-  if (error) {
-    return <div className={styles.error}>Error: {error}</div>;
-  }
+  if (loading) { return <div className={styles.loading}>Loading patient data…</div>; }
+  if (error) { return <div className={styles.error}>Error: {error}</div>; }
 
   const weightHistory = patient!.weight_history || [];
 
   return (
     <div className={styles.container}>
       <h1 className={styles.header}>{patient!.first_name} {patient!.last_name}</h1>
-
       <PatientInfoSection 
         patientInfo={patient!.patient_info} 
         csrfToken={csrfToken}
         email={patient!.email} 
+        latestWeight={patient!.latest_weight} 
+        weightLastUpdated={patient!.latest_weight_timestamp}
       />
-
-      <div className={styles.details_container}>
-        <div className={styles.patient_info}>
-          <p><span className={styles.label}>Email:</span> {patient!.email}</p>
-          <p><span className={styles.label}>Latest Weight:</span> {patient!.latest_weight ? `${patient!.latest_weight} lbs` : "N/A"}</p>
-          <p><span className={styles.label}>Last Weight Update:</span> {patient!.latest_weight_timestamp ? new Date(patient!.latest_weight_timestamp).toLocaleString() : "N/A"}</p>
-        </div>
-
-        <ChartCalendarViz 
-          weightHistory={weightHistory} 
-          onDataPointSelect={handleDataPointSelect} 
+      <ChartCalendarViz 
+        weightHistory={weightHistory} 
+        onDataPointSelect={handleDataPointSelect} 
+      />
+      {selectedDay && (
+        <PatientNotesSection
+          selectedDay={selectedDay}
+          weightHistory={patient?.weight_history}
+          notes={patient?.notes}
+          addNoteText={addNoteText}
+          setAddNoteText={setAddNoteText}
+          handleKeyDown={handleKeyDown}
         />
-
-        {selectedDay && (
-          <PatientNotesSection
-            selectedDay={selectedDay}
-            weightHistory={patient?.weight_history}
-            notes={patient?.notes}
-            addNoteText={addNoteText}
-            setAddNoteText={setAddNoteText}
-            handleKeyDown={handleKeyDown}
-          />
-        )}
-
-        <div className={styles.button_container}>
-          <button className={styles.remove_patient_btn} onClick={handleRemovePatientRelationship}>Remove Patient</button>
-        </div>
-
+      )}
+      <div className={styles.button_container}>
+        <button className={styles.remove_patient_btn} onClick={handleRemovePatientRelationship}>Remove Patient</button>
       </div>
     </div>
   );

--- a/dww_provider/src/pages/PatientDetails.tsx
+++ b/dww_provider/src/pages/PatientDetails.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styles from "../styles/PatientDetails.module.css";
-import Chart from '../components/Chart';
-import Calendar from '../components/Calendar';
 import PatientInfoSection from '../components/PatientInfoSection';
 import PatientNotesSection from '../components/PatientNotesSection';
+import ChartCalendarViz from '../components/ChartCalendarViz';
 
 type WeightRecord = {
   weight: number;
@@ -188,53 +187,10 @@ const PatientDetails: React.FC = () => {
           <p><span className={styles.label}>Last Weight Update:</span> {patient!.latest_weight_timestamp ? new Date(patient!.latest_weight_timestamp).toLocaleString() : "N/A"}</p>
         </div>
 
-        <div className={styles.weight_history}>
-          <h2 className={styles.weight_history_title}>Weight History</h2>
-          <div className={styles.chart_slider_container}>
-            <button
-              className={styles.chart_left_button}
-              style={{
-                backgroundColor: chart === 'chart' ? '#7B5CB8' : 'white',
-                color: chart === 'chart' ? 'white' : 'gray'
-              }}
-              onClick={() => setChart('chart')}
-            >
-              Chart
-            </button>
-            <button
-              className={styles.chart_right_button}
-              style={{
-                backgroundColor: chart === 'calendar' ? '#7B5CB8' : 'white',
-                color: chart === 'calendar' ? 'white' : 'gray'
-              }}
-              onClick={() => setChart('calendar')}
-            >
-              Calendar
-            </button>
-          </div>
-          {weightHistory.length > 0 ? (
-            <div className={styles.chart_container}>
-              {chart === 'chart' ? 
-                <Chart
-                  weightRecord={weightHistory.map(r => ({
-                    timestamp: new Date(r.timestamp),
-                    weight: r.weight
-                  }))}
-                  onDataPointSelect={handleDataPointSelect}
-                /> : 
-                <Calendar
-                  weightRecord={weightHistory.map(r => ({
-                    timestamp: new Date(r.timestamp),
-                    weight: r.weight
-                  }))}
-                  onDataPointSelect={handleDataPointSelect}
-                />
-              }
-            </div>
-          ) : (
-            <p>No weight history available.</p>
-          )}
-        </div>
+        <ChartCalendarViz 
+          weightHistory={weightHistory} 
+          onDataPointSelect={handleDataPointSelect} 
+        />
 
         {selectedDay && (
           <PatientNotesSection

--- a/dww_provider/src/pages/PatientDetails.tsx
+++ b/dww_provider/src/pages/PatientDetails.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../components/AuthContext';
 import styles from "../styles/PatientDetails.module.css";
 import PatientInfoSection from '../components/PatientInfoSection';
 import PatientNotesSection from '../components/PatientNotesSection';
@@ -38,16 +39,18 @@ type Patient = {
 };
 
 const PatientDetails: React.FC = () => {
+  const navigate = useNavigate(); 
+  const { getCSRFToken } = useAuth();
+  const [csrfToken, setCsrfToken] = useState<string>(''); 
   const { id } = useParams<{ id: string }>();
+  
   const [error, setError] = useState<string | null>(null);
   const [patient, setPatient] = useState<Patient | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedDay, setSelectedDay] = useState(new Date());
-  const [chart, setChart] = useState('chart');
   const [addNoteText, setAddNoteText] = useState<string>(''); 
   const [refresh, setRefresh] = useState<boolean>(false); 
-  const [csrfToken, setCsrfToken] = useState<string>(''); 
-  const navigate = useNavigate(); 
+
 
   const handleRemovePatientRelationship = async () => {
     const confirmDelete = window.confirm(
@@ -116,15 +119,12 @@ const PatientDetails: React.FC = () => {
   };
 
   useEffect(() => {
-    const getCSRFToken = async () => {
-      const response = await fetch(`${process.env.VITE_PUBLIC_DEV_SERVER_URL}/get-csrf-token/`, {
-        credentials: 'include',
-      });
-      const data = await response.json();
-      setCsrfToken(data.csrfToken); 
+    const fetchToken = async () => {
+      const token = await getCSRFToken();
+      setCsrfToken(token);
     };
-    getCSRFToken(); 
-  }, []);
+    fetchToken();
+  }, [getCSRFToken]);
 
   useEffect(() => {
     const getPatientData = async () => {
@@ -178,7 +178,13 @@ const PatientDetails: React.FC = () => {
     <div className={styles.container}>
       <h1 className={styles.header}>{patient!.first_name} {patient!.last_name}</h1>
 
-      <PatientInfoSection patientInfo={patient!.patient_info} csrfToken={csrfToken}/>
+      <PatientInfoSection 
+        patientInfo={patient!.patient_info} 
+        csrfToken={csrfToken}
+        email={patient!.email} 
+        latestWeight={patient!.latest_weight}
+        weightLastUpdated={patient!.latest_weight_timestamp}
+      />
 
       <div className={styles.details_container}>
         <div className={styles.patient_info}>

--- a/dww_provider/src/pages/PatientDetails.tsx
+++ b/dww_provider/src/pages/PatientDetails.tsx
@@ -4,6 +4,7 @@ import styles from "../styles/PatientDetails.module.css";
 import Chart from '../components/Chart';
 import Calendar from '../components/Calendar';
 import PatientInfoSection from '../components/PatientInfoSection';
+import PatientNotesSection from '../components/PatientNotesSection';
 
 type WeightRecord = {
   weight: number;
@@ -235,79 +236,16 @@ const PatientDetails: React.FC = () => {
           )}
         </div>
 
-        <div className={styles.patient_info}>
-          <div className={styles.noteSection}>
-            <span className={styles.label}>Selected Day: </span> 
-            {selectedDay!.toLocaleDateString('en-US', {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })}
-          </div>
-          {selectedDay && (
-            <>
-              <div className={styles.noteSection}>
-                <span className={styles.label}>Weight Recorded: </span>
-                {patient?.weight_history?.filter(record => 
-                    new Date(record.timestamp).getFullYear() === selectedDay.getFullYear() &&
-                    new Date(record.timestamp).getMonth() === selectedDay.getMonth() &&
-                    new Date(record.timestamp).getDate() === selectedDay.getDate()
-                  ).map((record, index) => (
-                    <div key={index} className={styles.noteItem}>
-                      <span className={styles.noteValue}>
-                        {record.weight} lbs
-                      </span>
-                      <span className={styles.noteTime}>
-                        {new Date(record.timestamp).toLocaleTimeString('en-US', {
-                          hour: '2-digit',
-                          minute: '2-digit'
-                        })}
-                      </span>
-                    </div>
-                  ))}
-                {!patient?.weight_history?.some(record => 
-                  new Date(record.timestamp).getFullYear() === selectedDay.getFullYear() &&
-                  new Date(record.timestamp).getMonth() === selectedDay.getMonth() &&
-                  new Date(record.timestamp).getDate() === selectedDay.getDate()
-                ) && (
-                  <span>No weight records for this day</span>
-                )}
-              </div>
-
-              <div className={styles.noteSection}>
-                <span className={styles.label}>Notes: </span>
-                {patient?.notes?.filter(note => 
-                    note.timestamp.toDateString() === selectedDay.toDateString()
-                  )
-                  .map((note, index) => (
-                    <div key={index} className={styles.noteItem}>
-                      <span className={styles.noteText}>{note.note}</span>
-                      <span className={styles.noteTime}>
-                        {note.timestamp.toLocaleTimeString('en-US', {
-                          hour: '2-digit',
-                          minute: '2-digit'
-                        })}
-                      </span>
-                    </div>
-                  ))}
-                
-                {!patient?.notes?.some(note => 
-                  note.timestamp.toDateString() === selectedDay.toDateString()
-                ) && (
-                  <span> No notes for this day</span>
-                )}
-              </div>
-              <textarea 
-                  value={addNoteText} 
-                  onChange={e => setAddNoteText(e.target.value)} 
-                  onKeyDown={handleKeyDown}
-                  className={styles.addNoteText} 
-                  placeholder="Type a note and press Enter..."
-              />
-            </>
-          )}
-        </div>
+        {selectedDay && (
+          <PatientNotesSection
+            selectedDay={selectedDay}
+            weightHistory={patient?.weight_history}
+            notes={patient?.notes}
+            addNoteText={addNoteText}
+            setAddNoteText={setAddNoteText}
+            handleKeyDown={handleKeyDown}
+          />
+        )}
 
         <div className={styles.button_container}>
           <button className={styles.remove_patient_btn} onClick={handleRemovePatientRelationship}>Remove Patient</button>

--- a/dww_provider/src/pages/PatientDetails.tsx
+++ b/dww_provider/src/pages/PatientDetails.tsx
@@ -1,49 +1,23 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../components/AuthContext';
+import { PatientNote, Patient } from '../utils/types'; 
+
 import styles from "../styles/PatientDetails.module.css";
+
 import PatientInfoSection from '../components/PatientInfoSection';
 import PatientNotesSection from '../components/PatientNotesSection';
 import ChartCalendarViz from '../components/ChartCalendarViz';
 
-type WeightRecord = {
-  weight: number;
-  timestamp: string;
-}
 
-type PatientNote = {
-  timestamp: Date,
-  note: string,
-}
-
-interface PatientInfo {
-  patient?: number; 
-  date_of_birth?: string;
-  sex?: string;
-  height?: string;
-  medications?: string;
-  other_info?: string;
-  last_updated?: Date; 
-}
-
-type Patient = {
-  id: number;
-  first_name: string;
-  last_name: string;
-  email: string;
-  latest_weight: number | null;
-  latest_weight_timestamp: string | null;
-  weight_history?: WeightRecord[];
-  notes?: PatientNote[];
-  patient_info?: PatientInfo; 
-};
 
 const PatientDetails: React.FC = () => {
+
   const navigate = useNavigate(); 
   const { getCSRFToken } = useAuth();
   const [csrfToken, setCsrfToken] = useState<string>(''); 
   const { id } = useParams<{ id: string }>();
-  
+
   const [error, setError] = useState<string | null>(null);
   const [patient, setPatient] = useState<Patient | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -139,14 +113,19 @@ const PatientDetails: React.FC = () => {
         }
         const data = await res.json();
 
-        // convert timestamps in notes to Date objects
+        // convert timestamps to Date objects
         if (data.notes) {
           data.notes = data.notes.map((note: PatientNote) => ({
             ...note,
             timestamp: new Date(note.timestamp),
           }));
         }
-
+        if (data.weight_history) {
+          data.weight_history = data.weight_history.map((record: any) => ({
+            ...record,
+            timestamp: new Date(record.timestamp),
+          }));
+        }
         if (data.patient_info?.last_updated) {
           data.patient_info.last_updated = new Date(data.patient_info.last_updated);
         }
@@ -182,8 +161,6 @@ const PatientDetails: React.FC = () => {
         patientInfo={patient!.patient_info} 
         csrfToken={csrfToken}
         email={patient!.email} 
-        latestWeight={patient!.latest_weight}
-        weightLastUpdated={patient!.latest_weight_timestamp}
       />
 
       <div className={styles.details_container}>

--- a/dww_provider/src/styles/ChartCalendarViz.module.css
+++ b/dww_provider/src/styles/ChartCalendarViz.module.css
@@ -1,0 +1,49 @@
+.weight-history {
+    margin-top: 20px;
+    padding: 15px;
+    background-color: #e7f5ff;
+    border-radius: 8px;
+}
+
+.weight_history_title {
+    text-align: center;
+    color: black;
+    font-size: 18px;
+    font-weight: bold;
+}
+
+.chart_slider_container {
+    padding: 10px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    background-color: white;
+}
+
+.chart_left_button {
+    padding: 12px;
+    border-top-left-radius: 20px;
+    border-bottom-left-radius: 20px;
+    max-width: 120px;
+    min-width: 100px;
+    align-items: center;
+    border: 1px solid #7B5CB8;
+}
+
+.chart_right_button {
+    padding: 12px;
+    border-top-right-radius: 20px;
+    border-bottom-right-radius: 20px;
+    max-width: 120px;
+    min-width: 100px;
+    align-items: center;
+    border: 1px solid #7B5CB8;
+}
+
+.chart-container {
+    margin-top: 20px;
+    background-color: #ffffff;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
+}

--- a/dww_provider/src/styles/ChartCalendarViz.module.css
+++ b/dww_provider/src/styles/ChartCalendarViz.module.css
@@ -1,8 +1,7 @@
-.weight-history {
+
+.weight_history {
     margin-top: 20px;
     padding: 15px;
-    background-color: #e7f5ff;
-    border-radius: 8px;
 }
 
 .weight_history_title {
@@ -12,8 +11,8 @@
     font-weight: bold;
 }
 
-.chart_slider_container {
-    padding: 10px;
+.chart_button_container {
+    padding: 1px 10px 10px 10px;
     display: flex;
     flex-direction: row;
     justify-content: center;
@@ -40,8 +39,7 @@
     border: 1px solid #7B5CB8;
 }
 
-.chart-container {
-    margin-top: 20px;
+.chart_container {
     background-color: #ffffff;
     padding: 15px;
     border-radius: 8px;

--- a/dww_provider/src/styles/PatientDetails.module.css
+++ b/dww_provider/src/styles/PatientDetails.module.css
@@ -30,48 +30,6 @@
     font-weight: bold;
 }
 
-.chart_slider_container {
-    padding: 10px;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    background-color: white;
-}
-
-.chart_left_button {
-    padding: 12px;
-    border-top-left-radius: 20px;
-    border-bottom-left-radius: 20px;
-    max-width: 120px;
-    min-width: 100px;
-    align-items: center;
-    border: 1px solid #7B5CB8;
-}
-
-.chart_right_button {
-    padding: 12px;
-    border-top-right-radius: 20px;
-    border-bottom-right-radius: 20px;
-    max-width: 120px;
-    min-width: 100px;
-    align-items: center;
-    border: 1px solid #7B5CB8;
-}
-
-.weight-history {
-    margin-top: 20px;
-    padding: 15px;
-    background-color: #e7f5ff;
-    border-radius: 8px;
-}
-
-.weight_history_title {
-    text-align: center;
-    color: black;
-    font-size: 18px;
-    font-weight: bold;
-}
-
 .error {
     text-align: center;
     font-size: 18px;
@@ -85,14 +43,6 @@
     font-size: 18px;
     color: black;
     margin-top: 20px;
-}
-
-.chart-container {
-    margin-top: 20px;
-    background-color: #ffffff;
-    padding: 15px;
-    border-radius: 8px;
-    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .noteContent {

--- a/dww_provider/src/styles/PatientInfoSection.module.css
+++ b/dww_provider/src/styles/PatientInfoSection.module.css
@@ -1,12 +1,76 @@
-
 .basicInfoHeader {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    padding: 8px 0;
+    border-bottom: 1px solid #ccc;
+    font-size: 1.1rem;
+}
+
+.lastUpdatedText {
+    font-size: 0.9rem;
+    color: #222;
+    margin-top: 2px;
+  }
+
+.updateSaveText {
+    color: blue;
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: 0.95rem;
+}
+
+.infoRow {
+    margin: 10px 0;
+    display: flex;
+    justify-content: space-between;
+}
+
+.infoRow strong {
     margin-bottom: 4px;
 }
 
-.updateSaveText {
-    color: blue; 
-    text-decoration: underline;
-    cursor: pointer; 
+.infoRow input,
+.infoRow select {
+    padding: 4px;
+    font-size: 1rem;
+    max-width: 250px;
+}
+
+.latestWeight {
+    margin-top: 12px;
+    padding-top: 8px;
+    border-top: 1px solid #ccc;
+    font-weight: 500;
+}
+
+.medicationsTextarea {
+    font-family: inherit; 
+    width: 100%;
+    max-width: 400px;
+    resize: vertical;
+    padding: 2px 6px;
+    font-size: 1rem;
+    box-sizing: border-box;
+}
+
+.otherInfoTextarea {
+    font-family: inherit; 
+    width: 100%;
+    max-width: 400px;
+    min-height: 5rem;
+    resize: vertical;
+    padding: 2px 6px;
+    font-size: 1rem;
+    box-sizing: border-box;
+}
+
+.textBlock {
+    display: block;
+    max-width: 400px;
+    white-space: pre-wrap; /* preserves line breaks if any */
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    text-align: justify;
 }

--- a/dww_provider/src/utils/types.ts
+++ b/dww_provider/src/utils/types.ts
@@ -1,0 +1,77 @@
+
+
+//// supporting types 
+
+export type WeightRecord = {
+    timestamp: Date; 
+    weight: number; 
+}; 
+
+export type PatientNote = {
+    timestamp: Date; 
+    note: string; 
+}; 
+
+export type PatientInfo = {
+    patient?: number;
+    height?: string;
+    date_of_birth?: string; // optional + string for input binding
+    sex?: string;
+    medications?: string;
+    other_info?: string;
+    last_updated?: Date | null;
+};
+
+
+
+//// types for interacting with Django API 
+
+// add_patient_note View 
+export type PatientNoteAPI = {
+    patient: number; 
+    note_type: string; 
+    timestamp: Date; 
+    note: string; 
+}; 
+
+// add_patient_info View 
+export type PatientInfoAPI = Omit<PatientInfo, 'last_updated'>;
+
+// get_patient_data View 
+export type Patient = {
+    id: number;
+    first_name: string;
+    last_name: string;
+    email: string;
+    latest_weight: number | null;
+    latest_weight_timestamp: string | null;
+    weight_history?: WeightRecord[];
+    notes?: PatientNote[];
+    patient_info?: PatientInfo; 
+}; 
+
+
+
+//// prop types for child components of PatientDetails 
+
+export type PatientInfoSectionProps = {
+    patientInfo?: PatientInfo;
+    csrfToken: string;
+    email: string; 
+    latestWeight?: number; 
+    weightLastUpdated?: Date; 
+}; 
+
+export type PatientNotesSectionProps = {
+    selectedDay: Date;
+    weightHistory?: WeightRecord[];
+    notes?: PatientNote[];
+    addNoteText: string;
+    setAddNoteText: (text: string) => void;
+    handleKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+};
+
+export type ChartCalendarVizProps = {
+    weightHistory: WeightRecord[];
+    onDataPointSelect: (day: Date) => void;
+}; 

--- a/dww_provider/src/utils/types.ts
+++ b/dww_provider/src/utils/types.ts
@@ -43,8 +43,8 @@ export type Patient = {
     first_name: string;
     last_name: string;
     email: string;
-    latest_weight: number | null;
-    latest_weight_timestamp: string | null;
+    latest_weight: number;
+    latest_weight_timestamp: Date;
     weight_history?: WeightRecord[];
     notes?: PatientNote[];
     patient_info?: PatientInfo; 


### PR DESCRIPTION
I was having trouble implementing my tasks in PatientDetails so I decided to spend some time refactoring/cleaning to make stuff easier to understand first. 
- most of the JSX returned by `PatientDetails.tsx` has been split into three subcomponents: `PatientInfoSection`, `ChartCalendarViz`, and `PatientNotesSection` 
- all of the relevant TS types have been moved to a file `src/utils/types.ts` so we don't have to declare them inside the components. Types have been modified a bit for clarity. 
- PatientDetails was previously implementing its own function to get the CSRF token instead of using the one provided by AuthProvider - this is fixed 
- made some UI improvements to the PatientInfoSection