### PR TITLE
Patient verification email

### DIFF
--- a/dww_backend/api/urls.py
+++ b/dww_backend/api/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('test/', shared_views.test, name='test'), 
     path('login/', shared_views.login_view, name='login'),
     path('logout/', shared_views.logout_view, name='logout'), 
+    path('verify-email/', shared_views.verify_email, name='verify_email'), 
     ## account management 
     path('delete-account/', shared_views.delete_account, name='delete_account'),
     path('delete-relationship/', shared_views.delete_relationship, name='delete_provider'),
@@ -41,5 +42,4 @@ urlpatterns = [
     path('get-patient-data/', provider_views.get_patient_data, name='get_patient_data'),
     path('add-patient-note', provider_views.add_patient_note, name='add_patient_note'), 
     path('add-patient-info', provider_views.add_patient_info, name='add_patient_info'), 
-    path('verify-email/', provider_views.verify_email, name='verify_email'), 
 ]

--- a/dww_backend/api/views/patient_views.py
+++ b/dww_backend/api/views/patient_views.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework_simplejwt.authentication import JWTAuthentication 
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError
-
+from api.views.shared_views import send_verification_email
 
 """
 Note: All patient-facing APIs should use rest_framework's JWT authentication
@@ -47,7 +47,8 @@ def register(request):
         data = json.loads(request.body)
         form = RegisterUserForm(data)
         if form.is_valid():
-            form.save()
+            user = form.save()
+            send_verification_email(user)
             return JsonResponse({'message': "User registered successfully"}, status=201)
         else:
             print(form.errors)

--- a/dww_backend/api/views/provider_views.py
+++ b/dww_backend/api/views/provider_views.py
@@ -15,6 +15,7 @@ import json
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.authentication import SessionAuthentication
+from api.views.shared_views import send_verification_email
 
 """
 Note: All provider-facing APIs should use Django's built-in (session-based) authentication 
@@ -206,69 +207,3 @@ def add_patient_info(request):
     
     print(f'Serializer errors: {serializer.errors}')
     return JsonResponse({'error': 'Invalid JSON'}, status=400) 
-
-def send_verification_email(user):
-    token = get_random_string(50)
-    user.verification_token = token
-    user.save()
-
-    verification_url = f"{settings.FRONTEND_URL}/verify-email?token={token}"
-
-    subject = 'Verify Your Email'
-    
-    # Create HTML content
-    html_message = f"""
-    <html>
-      <body style="font-family: Arial, sans-serif; background-color: #f9f9f9; margin: 0; padding: 20px;">
-        <table width="100%" cellpadding="0" cellspacing="0" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border: 1px solid #ddd; border-radius: 8px; padding: 20px;">
-          <tr>
-            <td style="text-align: center; padding-bottom: 20px;">
-              <h1 style="color: #333; font-size: 24px;">Welcome to Dry Weight Watchers!</h1>
-              <p style="color: #555; font-size: 16px;">Please verify your email address to activate your account.</p>
-            </td>
-          </tr>
-          <tr>
-            <td style="text-align: center; padding: 20px;">
-              <a href="{verification_url}" target="_blank" 
-                 style="display: inline-block; padding: 12px 24px; font-size: 16px; color: #ffffff; background-color: #007bff; 
-                        text-decoration: none; border-radius: 4px; font-weight: bold;">
-                Verify Email
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td style="text-align: center; padding-top: 20px; font-size: 14px; color: #999;">
-              If you didn't create an account, you can ignore this email.
-            </td>
-          </tr>
-        </table>
-      </body>
-    </html>
-    """
-
-    from_email = settings.EMAIL_HOST_USER
-    recipient_list = [user.email]
-
-    try:
-        send_mail(
-            subject,
-            '',
-            from_email,
-            recipient_list,
-            html_message=html_message,
-            fail_silently=False,
-        )
-    except Exception as e:
-        raise e
-
-
-@api_view(['GET'])
-def verify_email(request):
-    token = request.GET.get('token')
-    user = get_object_or_404(User, verification_token=token)
-
-    user.is_verified = True
-    user.verification_token = None
-    user.save()
-
-    return JsonResponse({'message': 'Email verified successfully'})

--- a/dww_patient/app/auth/LoginScreen.tsx
+++ b/dww_patient/app/auth/LoginScreen.tsx
@@ -30,7 +30,6 @@ const LoginScreen = () => {
         console.log("LoginScreen: handleLogin: response returned with 200 OK")
         const data = await response.json();
         await login(data.access_token, data.refresh_token);
-
       } else {
         const errorData = await response.json();
         Alert.alert(`Error ${response.status}: ${errorData.message}`);

--- a/dww_patient/app/auth/SignupScreen.tsx
+++ b/dww_patient/app/auth/SignupScreen.tsx
@@ -30,6 +30,7 @@ const SignupScreen = () => {
       const response = await axios.post(`${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/register/`, data);
 
       console.log('Signup successful:', response.data);
+      alert('A verification email has been sent to ' + email)
       navigation.navigate('Login');
     } catch (error: any) {
       if (error.response?.data?.errors) { 


### PR DESCRIPTION
Quick addition of verification emails using same views made by Lara.

TODO:
- Delete account has a bug where you can't delete an account twice as the deleted account email exists in deletedUsers table. It sounds like trouble, but I believe we should delete users via an entry in their user model, i.e. set deleted? = 1 if delete. 
This way we preserve information and can easily reactivate with all information if needed. This of course, would be very tedious to add as we would need to add "is deleted?" checks everywhere to exclude deleted users from showing up in things like ProviderList or PatientDetails.
- I tested email verification after the first commit, but didn't after moving things to shared_view and shifting url around. I don't believe it'll affect anything but yknow.