### PR TITLE
dashboard risk indicators by threshold

### DIFF
--- a/dww_backend/api/views/provider_views.py
+++ b/dww_backend/api/views/provider_views.py
@@ -1,4 +1,5 @@
 
+from datetime import timedelta
 from django.http import JsonResponse
 from django.contrib.auth import authenticate, logout, login as django_login
 from django.middleware.csrf import get_token
@@ -87,18 +88,49 @@ def dashboard(request):
         provider_id=provider.id 
     ).values_list('patient_id', flat=True)
 
-    # subquery to get the most recent weight record for each patient 
+    # subquery to get the latest weight and timestamp
     latest_weight_subquery = WeightRecord.objects.filter(
         patient_id=OuterRef('id')
-    ).order_by('-timestamp').values_list('weight', 'timestamp')[:1] 
+    ).order_by('-timestamp')
 
-    # main query to get all needed info 
-    patients = User.objects.filter(id__in=patient_ids, role='patient').annotate(
-        latest_weight=Subquery(latest_weight_subquery.values_list('weight', flat=True)),
-        latest_weight_timestamp=Subquery(latest_weight_subquery.values_list('timestamp', flat=True))
-    ).values('id', 'first_name', 'last_name', 'email', 'latest_weight', 'latest_weight_timestamp')
+    # subquery to get alarm_threshold from related PatientInfo
+    alarm_threshold_subquery = PatientInfo.objects.filter(
+        patient_id=OuterRef('id')
+    ).values('alarm_threshold')[:1]
 
-    return JsonResponse({'patients': list(patients)})
+    patients_qs = User.objects.filter(id__in=patient_ids, role='patient').annotate(
+        latest_weight=Subquery(latest_weight_subquery.values_list('weight', flat=True)[:1]),
+        latest_weight_timestamp=Subquery(latest_weight_subquery.values_list('timestamp', flat=True)[:1]),
+        alarm_threshold=Subquery(alarm_threshold_subquery)
+    ).values(
+        'id', 'first_name', 'last_name', 'email',
+        'latest_weight', 'latest_weight_timestamp',
+        'alarm_threshold'
+    )
+    patients = list(patients_qs)
+
+    # get prev weight/timestamp that is at least one day before the latest 
+    for patient in patients:
+        patient_id = patient['id']
+        latest_timestamp = patient['latest_weight_timestamp']
+
+        if latest_timestamp:
+            prev_record = (
+                WeightRecord.objects.filter(
+                    patient_id=patient_id,
+                    timestamp__date__lt=latest_timestamp.date()
+                )
+                .order_by('-timestamp')
+                .values('weight', 'timestamp')
+                .first()
+            )
+        else:
+            prev_record = None
+
+        patient['prev_weight'] = prev_record['weight'] if prev_record else None
+        patient['prev_weight_timestamp'] = prev_record['timestamp'] if prev_record else None
+
+    return JsonResponse({'patients': patients})
 
 
 @api_view(['GET'])
@@ -130,7 +162,7 @@ def get_patient_data(request):
     # get patient fields 
     patient_info = PatientInfo.objects.filter(
         patient_id=patient_id
-    ).values('height', 'date_of_birth', 'sex', 'medications', 'other_info', 'last_updated'
+    ).values('height', 'date_of_birth', 'sex', 'medications', 'other_info', 'last_updated', 'alarm_threshold'
     ).first() or {} 
     default_patient_info = {
         'patient': patient_id, 
@@ -139,7 +171,8 @@ def get_patient_data(request):
         'sex': '',
         'medications': '',
         'other_info': '',
-        'last_updated': None 
+        'last_updated': None, 
+        'alarm_threshold': None
     }
     patient_info = {**default_patient_info, **patient_info}  # merging db data (if exists) into default object 
     

--- a/dww_provider/src/components/PatientInfoSection.tsx
+++ b/dww_provider/src/components/PatientInfoSection.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from '../styles/PatientInfoSection.module.css';
 import { PatientInfo, PatientInfoSectionProps } from '../utils/types'; 
 
@@ -10,10 +10,17 @@ const PatientInfoSection: React.FC<PatientInfoSectionProps> = ({
 }) => {
   const DEFAULT_ALARM_THRESHOLD = 2.0; 
   const [fields, setFields] = useState<PatientInfo>({
-    alarm_threshold: patientInfo?.alarm_threshold ?? DEFAULT_ALARM_THRESHOLD,
     ...patientInfo,
+    alarm_threshold: patientInfo?.alarm_threshold ?? DEFAULT_ALARM_THRESHOLD,
   });
   const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    setFields({
+      ...patientInfo,
+      alarm_threshold: patientInfo?.alarm_threshold ?? DEFAULT_ALARM_THRESHOLD
+    });
+  }, [patientInfo]);
 
   const handleEditClick = async () => {
     if (isEditing) {

--- a/dww_provider/src/pages/Dashboard.tsx
+++ b/dww_provider/src/pages/Dashboard.tsx
@@ -1,18 +1,14 @@
+
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import styles from '../styles/Dashboard.module.css';
+import styles from '../styles/Dashboard.module.css'; 
+import { DashboardPatient } from '../utils/types'; 
+import { avgDailyWeightChange } from '../utils/helpers';
 
-type Patient = {
-  id: number;
-  first_name: string;
-  last_name: string;
-  email: string;
-  latest_weight: number | null;
-  latest_weight_timestamp: string | null;
-};
 
 const Dashboard: React.FC = () => {
-  const [patients, setPatients] = useState<Patient[]>([]);
+  const DEFAULT_ALARM_THRESHOLD = 2.0; 
+  const [patients, setPatients] = useState<DashboardPatient[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
@@ -39,34 +35,78 @@ const Dashboard: React.FC = () => {
     fetchPatients();
   }, []);
 
-  if (loading) {
-    return <div>Loading patient data…</div>;
+  useEffect(() => {
+    console.log('Patients: ', patients); 
+  }, [patients]); 
+
+
+  const getPatientCardData = (patient: DashboardPatient) => {
+    const latestRecord =
+    patient.latest_weight !== null && patient.latest_weight_timestamp !== null
+      ? {
+          weight: patient.latest_weight,
+          timestamp: new Date(patient.latest_weight_timestamp),
+        }
+      : null;
+    const prevRecord = patient.prev_weight !== null && patient.prev_weight_timestamp !== null
+      ? {
+          weight: patient.prev_weight,
+          timestamp: new Date(patient.prev_weight_timestamp),
+        }
+      : null;
+
+    const latestWeight = patient.latest_weight ?? null; 
+    const dailyChange = avgDailyWeightChange(latestRecord, prevRecord); 
+    const threshold = patient.alarm_threshold ?? DEFAULT_ALARM_THRESHOLD; 
+    return { latestWeight, dailyChange, threshold }; 
   }
 
-  if (error) {
-    return <div>Error: {error}</div>;
-  }
+
+  if (loading) { return <div>Loading patient data…</div>; }
+  if (error) { return <div>Error: {error}</div>; }
 
   return (
     <div className={styles.dashboard}>
       <h1 className={styles.title}>Patient Dashboard</h1>
       <div className={styles.cardContainer}>
         {patients.map((patient) => {
-          let weightClass = styles.neutralWeight;
-          if (patient.latest_weight !== null) {
-            if (patient.latest_weight < 50) {
-              weightClass = styles.lowWeight;
-            } else if (patient.latest_weight > 150) {
-              weightClass = styles.atRiskWeight;
-            } else {
-              weightClass = styles.greatWeight;
-            }
+
+          const { latestWeight, dailyChange, threshold } = getPatientCardData(patient);
+          let cardStyle; 
+          if (dailyChange === null) { cardStyle = `${styles.noDailyChange}`; } 
+          else { 
+            cardStyle = (dailyChange > threshold) 
+            ? `${styles.aboveThreshold}` 
+            : `${styles.belowThreshold}`; 
+          }
+          let weightDisplay; 
+
+          if (latestWeight === null) { 
+            weightDisplay = 'No measurements yet.'
+          } else if (dailyChange === null) { 
+            weightDisplay = (
+              <>
+                {latestWeight} lbs &nbsp;
+                <div className={styles.dailyChange}>(recent change unknown)</div>
+              </>
+            );
+          } else {
+            const sign = dailyChange > 0 ? '+' : ''; 
+            weightDisplay = (
+              <>
+                {latestWeight}&nbsp;
+                <span className={styles.dailyChange}>
+                  ({sign}{dailyChange.toFixed(2)})
+                </span>&nbsp;
+                lbs
+              </>
+            );
           }
 
           return (
             <div
               key={patient.id}
-              className={`${styles.patientCard} ${weightClass}`}
+              className={`${styles.patientCard} ${cardStyle}`}
               onClick={() => navigate(`/patients/${patient.id}`)}
             >
               <div className={styles.patientInfo}>
@@ -76,7 +116,7 @@ const Dashboard: React.FC = () => {
               <div className={styles.weightInfo}>
                 <span className={styles.weightLabel}>LATEST WEIGHT</span>
                 <span className={styles.weightValue}>
-                  {patient.latest_weight !== null ? `${patient.latest_weight} lbs` : 'N/A'}
+                  {weightDisplay}
                 </span>
               </div>
               <p className={styles.timestamp}>

--- a/dww_provider/src/styles/Dashboard.module.css
+++ b/dww_provider/src/styles/Dashboard.module.css
@@ -23,7 +23,7 @@
   border-radius: 10px;
   padding: 6px 0 12px;
   width: 220px;
-  height: 140px;
+  height: 155px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
   text-align: center;
   display: flex;

--- a/dww_provider/src/styles/Dashboard.module.css
+++ b/dww_provider/src/styles/Dashboard.module.css
@@ -21,10 +21,10 @@
 .patientCard {
   background: white;
   border-radius: 10px;
-  padding: 15px;
+  padding: 6px 0 12px;
   width: 220px;
-  height: 130px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  height: 140px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
   text-align: center;
   display: flex;
   flex-direction: column;
@@ -39,13 +39,13 @@
 
 .patientInfo h3 {
   font-size: 16px;
-  margin: 5px 0;
+  margin: 4px 0px 0px;
   font-weight: bold;
 }
 
 .patientInfo p {
-  font-size: 12px;
-  color: #666;
+  font-size: 12.5px;
+  color: #555;
 }
 
 .weightInfo {
@@ -66,18 +66,46 @@
 }
 
 .timestamp {
-  font-size: 12px;
-  color: #888;
+  font-size: 12.5px;
+  color: #555;
 }
 
-.atRiskWeight .weightValue {
-  color: red;
+
+
+.dailyChange {
+    font-size: 0.8rem; 
+    color: #555;
 }
 
-.greatWeight .weightValue {
-  color: green;
+
+.patientCard.aboveThreshold {
+    border: 1.5px solid #cc0000; 
+    background-color: #ffe9e9; 
+}
+.aboveThreshold .weightValue {
+    color: #cc0000;
+}
+.aboveThreshold .dailyChange {
+    color: #cc0000; 
 }
 
-.neutralWeight .weightValue {
-  color: black;
+
+.patientCard.noDailyChange {
+    background-color: #ffffeb; 
 }
+.noDailyChange .dailyChange {
+    color: #cc5555;
+}
+
+
+.patientCard.belowThreshold {
+    border: 1px solid #006600;
+    background-color: #e6ffe6; 
+}
+.belowThreshold .weightValue {
+    color: #006600; 
+}
+.belowThreshold .dailyChange {
+    color: #006600; 
+}
+

--- a/dww_provider/src/utils/helpers.ts
+++ b/dww_provider/src/utils/helpers.ts
@@ -14,8 +14,9 @@ export const formatPhoneNumber = (phone: string | undefined) => {
 
 
 /**
- * Returns the avg change in weight over the last two measurements, if they were within the last week. 
+ * Returns the avg daily change in weight over the last two measurements, if they were within the last week. 
  * Patients are supposed to weigh themselves every day, but they may not. 
+ * Server currently ensures the last two returned measurements are at least 1 day apart. 
  */
 export const avgDailyWeightChange = (lastWeight: WeightRecord | null, prevWeight: WeightRecord | null) => {
     const dayInMs = 24 * 60 * 60 * 1000 

--- a/dww_provider/src/utils/types.ts
+++ b/dww_provider/src/utils/types.ts
@@ -45,13 +45,18 @@ export type Patient = {
     first_name: string;
     last_name: string;
     email: string;
-    latest_weight: number;
-    latest_weight_timestamp: Date;
+    latest_weight: number | null;
+    latest_weight_timestamp: Date | null;
     weight_history?: WeightRecord[];
     notes?: PatientNote[];
     patient_info?: PatientInfo; 
 }; 
 
+export type DashboardPatient = Patient & {
+    prev_weight: number | null;
+    prev_weight_timestamp: Date | null;
+    alarm_threshold: number | null; 
+};
 
 
 //// prop types for child components of PatientDetails 


### PR DESCRIPTION
Dashboard now styles the patient cards differently according to whether the difference in the last two weights is above the patient's threshold. If there aren't two records within the past week then the dashboard doesn't attempt to calculate a difference but instead says "Recent change unknown" and colors the card yellow. 

The following changes were made to the API: 
- `/get-patient-data` endpoint also returns the patient's `alarm_threshold` 
- `/dashboard` endpoint also returns the last two weights, ensuring that the earlier one is not on the same day as the later one (in case the patient weighed themselves multiple times in the same day) 