### PR TITLE
fix: patient sometimes stuck in invalid session due to cached jwts

### DIFF
--- a/dww_patient/app/home/settings/Account.tsx
+++ b/dww_patient/app/home/settings/Account.tsx
@@ -23,6 +23,7 @@ const AccountScreen = () => {
       } else {
         const errorData = await response.json();
         Alert.alert('Error', errorData.message || 'Logout failed');
+        await logout();  // fallback: clear tokens anyway so user doesn't get stuck logged in 
       }
     } catch (error) {
       console.error('Logout error:', error);

--- a/dww_patient/package-lock.json
+++ b/dww_patient/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.1.1",
         "axios": "^1.7.9",
+        "base-64": "^1.0.0",
         "dotenv": "^16.4.7",
         "expo": "~52.0.26",
         "expo-blur": "~14.0.3",
@@ -5270,6 +5271,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
     "node_modules/base64-js": {

--- a/dww_patient/package.json
+++ b/dww_patient/package.json
@@ -21,6 +21,7 @@
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.1.1",
     "axios": "^1.7.9",
+    "base-64": "^1.0.0",
     "dotenv": "^16.4.7",
     "expo": "~52.0.26",
     "expo-blur": "~14.0.3",
@@ -45,9 +46,7 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "^15.11.1",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5",
-    "expo-secure-store": "~14.0.1",
-    "expo-notifications": "~0.29.13"
+    "react-native-webview": "13.12.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/dww_patient/utils/jwt.ts
+++ b/dww_patient/utils/jwt.ts
@@ -1,0 +1,22 @@
+
+import { decode as atob } from 'base-64';
+
+
+export function decodeJwt(token: string) {
+    try {
+        const payload = token.split('.')[1];
+        const decoded = atob(payload); 
+        return JSON.parse(decoded);
+    } catch (e) {
+        return null;
+    }
+  }
+
+
+export function isTokenExpired(token: string): boolean {
+    const decoded = decodeJwt(token);
+    if (!decoded || !decoded.exp) return true;
+
+    const now = Math.floor(Date.now() / 1000); // current time in seconds
+    return decoded.exp < now;
+}


### PR DESCRIPTION
App now checks on startup that any stored access/refresh tokens are still valid. 

Previously, if the access token had expired, then the patient would still be considered "logged in" upon startup and sent to the home screen. However, all authenticated calls to the server, including to the logout endpoint, would fail, leaving the app stuck in an invalid state. This is fixed. 

Installed `base-64` package for JWT decoding, so you'll need to `npm install`. 