### PR TITLE
change token expiry from testing values to real-world values

### DIFF
--- a/dww_backend/core/settings.py
+++ b/dww_backend/core/settings.py
@@ -85,8 +85,8 @@ REST_FRAMEWORK = {
 
 
 SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=2),
-    "REFRESH_TOKEN_LIFETIME": timedelta(minutes=15),
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=14),
     "ROTATE_REFRESH_TOKENS": True,
     "BLACKLIST_AFTER_ROTATION": True,
     "ALGORITHM": "HS256",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "dww",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
The patient app's refresh tokens previously expired every 15min, making it so the user has to re-login. This was to help catch any bugs that may have existed with the auth system. 

As a reminder, access and refresh tokens are both automatically refreshed each time an authenticated endpoint is used as long as the current refresh token is still valid. So with the new values, the patient won't have to login again unless they don't interact with the app for two weeks. 