### PR TITLE
add loading indicators to patient screens

### DIFF
--- a/dww_patient/app/home/HomeScreen.tsx
+++ b/dww_patient/app/home/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Text, TouchableOpacity, View, StyleSheet, ScrollView } from 'react-native';
+import { Text, TouchableOpacity, View, StyleSheet, ScrollView, ActivityIndicator } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import type { HomeTabScreenProps, SettingsStackScreenProps } from '../types/navigation';
 import { authFetch } from '@/utils/authFetch';
@@ -29,7 +29,7 @@ const HomeScreen = () => {
   const navigation_settings = useNavigation<SettingsStackScreenProps<'Settings'>['navigation']>();
   const { accessToken, refreshAccessToken, logout } = useAuth();
   const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [userDataIsLoading, setUserDataIsLoading] = useState<boolean>(true);
   const [chart, setChart] = useState('chart');
 
   const fetchUserData = async () => {
@@ -49,7 +49,7 @@ const HomeScreen = () => {
     } catch (err: any) {
       setError(err.message);
     } finally {
-      setIsLoading(false);
+      setUserDataIsLoading(false);
     }
   }
 
@@ -58,11 +58,11 @@ const HomeScreen = () => {
       const response = await authFetch(
         `${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/get-weight-record/`,
         accessToken, refreshAccessToken, logout, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
       );
 
       if (!response.ok) {
@@ -95,10 +95,18 @@ const HomeScreen = () => {
     );
   };
 
-
   const handleDataPointSelect = (day: Date) => {
     navigation.navigate('Dashboard');
   };
+
+
+  if (userDataIsLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#7B5CB8" />
+      </View>
+    );
+  }
 
   return (
     <ScrollView style={styles.container}>
@@ -157,6 +165,12 @@ const HomeScreen = () => {
 };
 
 const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5F9FF',
+  },
   container: {
     flex: 1,
     backgroundColor: '#F5F9FF',

--- a/dww_patient/app/home/settings/AddProviderScreen.tsx
+++ b/dww_patient/app/home/settings/AddProviderScreen.tsx
@@ -80,6 +80,7 @@ const AddProviderScreen = () => {
                 <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
                     <SafeAreaView>
                         <View style={styles.container}>
+                        <Text style={styles.topText}>Enter your healthcare provider's ID to connect them to your account. This information should be given by your provider.</Text>
                             <View style={styles.inputContainer}>
                                 <View style={styles.inputGroup}>
                                 {code.map((char, index) => (
@@ -129,6 +130,13 @@ const styles = StyleSheet.create({
         backgroundColor: '#FFF9FF',
         paddingHorizontal: 20,
         paddingVertical: 30,
+    },
+    topText: {
+      marginTop: 40, 
+      marginBottom: 80,  
+      fontSize: 15, 
+      textAlign: 'center', 
+      color: '#333',
     },
     inputContainer: {
         alignItems: 'center',

--- a/dww_patient/app/home/settings/ProfileScreen.tsx
+++ b/dww_patient/app/home/settings/ProfileScreen.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Alert, Button, Text, StyleSheet, View, TextInput, TouchableOpacity, SafeAreaView, TouchableWithoutFeedback, ScrollView, KeyboardAvoidingView, Platform, Keyboard } from 'react-native';
+import { Alert, Button, Text, StyleSheet, View, TextInput, TouchableOpacity, 
+  SafeAreaView, TouchableWithoutFeedback, ScrollView, KeyboardAvoidingView, Platform, 
+  Keyboard, ActivityIndicator } from 'react-native';
 import { useAuth } from '../../auth/AuthProvider';
 import { useNavigation } from '@react-navigation/native';
 import { SettingsStackScreenProps } from '../../types/navigation';
@@ -115,6 +117,15 @@ const ProfileScreen = () => {
           setMessage('Failed to update password. Please try again.');
         }
       };
+    
+
+    if (isLoading) {
+      return (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color="#7B5CB8" />
+        </View>
+      );
+    }
 
     return (
       <KeyboardAvoidingView
@@ -210,6 +221,12 @@ const ProfileScreen = () => {
 };
 
 const styles = StyleSheet.create({
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: '#F5F9FF',
+    },
     mainContainer: {
       flex: 1,
       backgroundColor: '#F5F9FF',

--- a/dww_patient/app/home/settings/ProviderList.tsx
+++ b/dww_patient/app/home/settings/ProviderList.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
-import { Button, StyleSheet, Text, FlatList, View, TouchableOpacity, SafeAreaView} from 'react-native';
+import { Button, StyleSheet, Text, FlatList, View, TouchableOpacity, SafeAreaView, 
+  ActivityIndicator } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useAuth } from '../../auth/AuthProvider';
 import { authFetch } from '@/utils/authFetch';
@@ -11,6 +12,7 @@ const ProviderList = () => {
   const navigation = useNavigation<SettingsStackScreenProps<'ProviderList'>['navigation']>();
   const [providers, setProviders] = useState<Provider[]>([]); 
   const {accessToken, refreshAccessToken, logout} = useAuth();
+  const [isLoading, setIsLoading] = useState<boolean>(true); 
 
   useFocusEffect(
     useCallback(() => {
@@ -23,7 +25,8 @@ const ProviderList = () => {
         if (!accessToken) {
             await refreshAccessToken();
         }
-        const response = await authFetch(`${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/user/providers/`, accessToken, refreshAccessToken, logout, {
+        const response = await authFetch(`${process.env.EXPO_PUBLIC_DEV_SERVER_URL}/user/providers/`, 
+          accessToken, refreshAccessToken, logout, {
             method: 'GET',
             headers: {
                 'Authorization': `Bearer ${accessToken}`,
@@ -42,6 +45,8 @@ const ProviderList = () => {
         setProviders(data)
     } catch (error) {
         //console.error('Error fetching providers:', error);
+    } finally {
+      setIsLoading(false); 
     }
   }
 
@@ -73,6 +78,15 @@ const ProviderList = () => {
     } catch (error) {
         //console.error('Error deleting provider:', error);
     }
+  }
+
+
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#7B5CB8" />
+      </View>
+    );
   }
 
   return (
@@ -109,6 +123,12 @@ const ProviderList = () => {
 };
 
 const styles = StyleSheet.create({
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: '#F5F9FF',
+    },
     addButton: {
       alignItems: 'center',
       justifyContent: 'center',

--- a/dww_patient/app/home/settings/RemindersScreen.tsx
+++ b/dww_patient/app/home/settings/RemindersScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { View, ScrollView, Text, StyleSheet, TouchableOpacity, Modal, Button, Switch, Pressable } from 'react-native';
+import { View, ScrollView, Text, StyleSheet, TouchableOpacity, Modal, Button, Switch, 
+  Pressable, ActivityIndicator } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { Ionicons } from '@expo/vector-icons';
 import ReminderItem from '../../../assets/components/ReminderItem'
@@ -7,7 +8,8 @@ import { useNavigation } from '@react-navigation/native';
 import { SettingsStackScreenProps } from '../../types/navigation';
 import { useAuth } from '../../auth/AuthProvider';
 import { authFetch } from '../../../utils/authFetch'; 
-import { scheduleNotification, cancelAllNotifications, requestNotificationPermissions } from '../../../utils/reminderNotifications';
+import { scheduleNotification, cancelAllNotifications, 
+  requestNotificationPermissions } from '../../../utils/reminderNotifications';
 
 interface NotificationPreferences {
   push_notifications: boolean;
@@ -28,6 +30,8 @@ const RemindersScreen = () => {
     email_notifications: false
   });
   const [preferencesModalVisible, setPreferencesModalVisible] = useState(false);
+  const [preferencesAreLoading, setPreferencesAreLoading] = useState<boolean>(true); 
+  const [remindersAreLoading, setRemindersAreLoading] = useState<boolean>(true); 
 
   const fetchNotificationPreferences = async () => {
     try {
@@ -52,6 +56,8 @@ const RemindersScreen = () => {
       setNotificationPreferences(data);
     } catch (error: any) {
       alert('Failed to get your notification preferences. Please try again.');
+    } finally {
+      setPreferencesAreLoading(false); 
     }
   };
 
@@ -108,6 +114,8 @@ const RemindersScreen = () => {
       setReminders(parsedReminders);
     } catch (error: any) {
       alert('Failed to get your reminders. Please try again.')
+    } finally {
+      setRemindersAreLoading(false); 
     }
   };
   
@@ -248,6 +256,14 @@ const RemindersScreen = () => {
     setSelectedReminderID(-1);
   }
 
+  if (preferencesAreLoading || remindersAreLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#7B5CB8" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.container}>
@@ -347,6 +363,12 @@ const RemindersScreen = () => {
 };
 
 const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5F9FF',
+  },
   container: {
     paddingVertical: 16,
     flex: 1,


### PR DESCRIPTION
I reviewed all the patient screens and added loading indicators ("spinners") where appropriate. I only added a spinner to a screen if it fetches data from the server - if it doesn't, then it should load immediately anyway since the screen code is already bundled with the app: 
- `HomeScreen` fetches two things - user data and weight records. The screen shows a spinner until the user data is fetched, but does not wait until after the weight data is fetched (to minimize wait time when the user starts the app). Instead, the chart will just re-render once the weight data is fetched. We could have a separate spinner just for the chart, but imo it's better to have the old data shown for a second since the visual update reminds the user of recent measurements anyway and is less jarring than having a spinner. 
- `DashboardScreen` fetches three things - user data, weight records, and notes. The screen shows a spinner until the user data and weights are fetched, since those are used to render the chart, which is the main thing the user probably wants to look at on the screen. The notes section has a separate spinner while the notes are being fetched, since the user would have to take an extra second to scroll down to see them anyway, and we don't want to add to the time it takes for the page to render. 
- `EnterDataScreen` doesn't fetch anything so we don't show it loading, though it does use a spinner when waiting for the scale. 
- `ProfileScreen` spins until profile info is fetched. 
- `NotificationScreen` spins until both notification preferences and reminders are fetched. 
- `SettingsScreen`, `AccountScreen`, `AddProviderScreen`, and `ChangePasswordScreen` don't fetch anything so they have no spinner. 

I also added some text at the top of the `AddProviderScreen` to explain to the patient about the Provider ID. 